### PR TITLE
docs: add translated READMEs (13 languages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
+<p align="center">
+  <a href="docs/translations/README.ar.md">العربية</a> •
+  <a href="docs/translations/README.de.md">Deutsch</a> •
+  <b>English</b> •
+  <a href="docs/translations/README.es.md">Español</a> •
+  <a href="docs/translations/README.fr.md">Français</a> •
+  <a href="docs/translations/README.it.md">Italiano</a> •
+  <a href="docs/translations/README.ja.md">日本語</a> •
+  <a href="docs/translations/README.ko.md">한국어</a> •
+  <a href="docs/translations/README.nl.md">Nederlands</a> •
+  <a href="docs/translations/README.pl.md">Polski</a> •
+  <a href="docs/translations/README.pt-BR.md">Português (BR)</a> •
+  <a href="docs/translations/README.ru.md">Русский</a> •
+  <a href="docs/translations/README.tr.md">Türkçe</a> •
+  <a href="docs/translations/README.zh-CN.md">简体中文</a>
+</p>
+
 <h1>
   <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
   Escalated

--- a/docs/translations/README.ar.md
+++ b/docs/translations/README.ar.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <b>العربية</b> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated هو نظام تذاكر دعم قابل للتضمين مع تتبع اتفاقيات مستوى الخدمة (SLA)، وقواعد التصعيد، وسير عمل الوكلاء، وبوابة العملاء. يحتوي هذا المستودع على جميع أصول الواجهة الأمامية المشتركة (Vue 3 + Inertia.js) المستخدمة عبر جميع أُطر العمل الخلفية المدعومة.
+
+👉 **تعرف على المزيد، شاهد العروض التوضيحية، وقارن بين خيارات السحابة والاستضافة الذاتية على** **[https://escalated.dev](https://escalated.dev)**
+
+**لا تقم بتثبيت هذه الحزمة مباشرة.** ابدأ بحزمة الواجهة الخلفية لإطار العمل الخاص بك — فهي تتولى كل شيء بما في ذلك سحب أصول الواجهة الأمامية هذه.
+
+## الميزات
+
+- **تقسيم التذاكر** — قسّم رداً إلى تذكرة مستقلة جديدة مع الحفاظ على السياق
+- **تأجيل التذاكر** — أجّل التذاكر مع خيارات محددة مسبقاً (ساعة، 4 ساعات، غداً، الأسبوع القادم) وإيقاظ تلقائي
+- **العروض المحفوظة / قوائم الانتظار المخصصة** — احفظ وسمّ وشارك إعدادات التصفية المسبقة كعروض تذاكر قابلة لإعادة الاستخدام
+- **أداة دعم قابلة للتضمين** — أداة `<script>` جاهزة للإدراج مع بحث قاعدة المعرفة ونموذج التذاكر والتحقق من الحالة
+- **تحديثات في الوقت الفعلي** — دعم WebSocket (Pusher/Reverb/Soketi) مع بديل الاستطلاع التلقائي
+- **تبديل قاعدة المعرفة** — تفعيل أو تعطيل قاعدة المعرفة العامة من إعدادات المسؤول
+- **CI: ESLint + Prettier** — فرض نمط الكود تلقائياً في كل طلب سحب
+
+## ابدأ الآن
+
+اختر إطار العمل الخاص بك:
+
+| إطار العمل | المستودع | التثبيت |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [تحميل escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | انظر [إعداد pubspec.yaml](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+كل مستودع خلفي يحتوي على تعليمات إعداد كاملة — أمر التثبيت، الترحيلات، الإعدادات، وتكامل الواجهة الأمامية.
+
+## Tailwind CSS
+
+تستخدم مكونات Escalated فئات Tailwind CSS. **يجب** عليك إضافة هذه الحزمة إلى تكوين `content` الخاص بـ Tailwind حتى لا يتم حذف فئاتها:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... المسارات الموجودة لديك
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+بدون هذا، ستُعرض واجهة Escalated ولكن الأنماط مثل خلفيات الأزرار وألوان الشارات ستكون مفقودة.
+
+## التخصيص
+
+يُعرض Escalated داخل تخطيط مستقل بشكل افتراضي. لدمجه في نظام التصميم الخاص بتطبيقك، استخدم `EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### تكامل التخطيط
+
+مرر مكون تخطيط تطبيقك وستُعرض جميع صفحات Escalated بداخله تلقائياً. يجب أن يقبل مكون التخطيط فتحة `#header` وفتحة افتراضية:
+
+```vue
+<!-- يجب أن يدعم تخطيطك هذه الفتحات -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+عندما لا يتم تقديم تخطيط، يستخدم Escalated شريط التنقل المدمج الخاص به.
+
+### خصائص CSS المخصصة
+
+يعيّن خيار `theme` خصائص CSS مخصصة يمكنك الرجوع إليها في أنماطك الخاصة:
+
+| الخاصية | الافتراضي | الوصف |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | لون الإجراء الأساسي |
+| `--esc-primary-hover` | تعتيم تلقائي | لون التمرير الأساسي |
+| `--esc-radius` | `0.5rem` | نصف قطر الحدود للمدخلات والأزرار |
+| `--esc-radius-lg` | تحجيم تلقائي | نصف قطر الحدود للبطاقات واللوحات |
+| `--esc-font-family` | وراثة | تجاوز عائلة الخط |
+
+### أمثلة الأُطر
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## ما في هذا المستودع
+
+جميع مكونات Vue 3 + Inertia.js التي تشغّل واجهة Escalated. هذه متطابقة عبر Laravel وRails وDjango وAdonisJS — يعرضها إطار العمل الخلفي عبر Inertia.
+
+## 📸 لقطات الشاشة
+
+> يتم إنشاء لقطات الشاشة تلقائياً من Storybook عبر سير عمل [component-screenshots](.github/workflows/screenshots.yml).
+
+<p align="center">
+  <strong>لوحة المسؤول (داكن)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="لوحة مسؤول Escalated — الوضع الداكن مع التنقل الجانبي وبطاقات KPI والإحصائيات وقائمة التذاكر" width="800" />
+</p>
+
+<p align="center">
+  <strong>لوحة المسؤول (فاتح)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="لوحة مسؤول Escalated — الوضع الفاتح مع التنقل الجانبي وبطاقات KPI والإحصائيات وقائمة التذاكر" width="800" />
+</p>
+
+<p align="center">
+  <strong>قائمة التذاكر</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="قائمة تذاكر Escalated — قائمة تذاكر الوكيل مع المرشحات والبحث والإجراءات المجمعة ومؤشرات SLA" width="800" />
+</p>
+
+<p align="center">
+  <strong>لوحة الوكيل</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="لوحة وكيل Escalated — التنقل العلوي والإحصائيات وقائمة التذاكر المعينة" width="800" />
+</p>
+
+<p align="center">
+  <strong>عرض تفاصيل التذكرة</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="عرض تفاصيل تذكرة Escalated — سلسلة المحادثة ومحرر الرد والشريط الجانبي للتذكرة مع مؤقت SLA" width="800" />
+</p>
+
+### الصفحات
+
+**بوابة العملاء** — إدارة التذاكر بالخدمة الذاتية
+- `pages/Customer/Index.vue` — قائمة التذاكر مع مرشحات الحالة والبحث
+- `pages/Customer/Create.vue` — نموذج تذكرة جديدة مع مرفقات الملفات
+- `pages/Customer/Show.vue` — تفاصيل التذكرة مع سلسلة الردود
+
+**لوحة الوكيل** — قائمة التذاكر وسير العمل
+- `pages/Agent/Dashboard.vue` — نظرة عامة على الإحصائيات والتذاكر الأخيرة
+- `pages/Agent/TicketIndex.vue` — قائمة تذاكر قابلة للتصفية
+- `pages/Agent/TicketShow.vue` — عرض تذكرة كامل مع الشريط الجانبي والملاحظات الداخلية والردود الجاهزة
+
+**لوحة المسؤول** — تكوين النظام
+- `pages/Admin/Reports.vue` — لوحة التحليلات
+- `pages/Admin/Departments/` — إدارة الأقسام (CRUD)
+- `pages/Admin/SlaPolicies/` — إدارة سياسات SLA
+- `pages/Admin/EscalationRules/` — منشئ قواعد التصعيد
+- `pages/Admin/Tags/` — إدارة العلامات
+- `pages/Admin/CannedResponses/` — قوالب الردود الجاهزة
+
+### المكونات المشتركة
+
+كتل بناء قابلة لإعادة الاستخدام تُستخدم عبر الصفحات أعلاه.
+
+| المكون | الوصف |
+|-----------|-------------|
+| `StatusBadge` | شارة ملونة لحالة التذكرة |
+| `PriorityBadge` | شارة ملونة لأولوية التذكرة |
+| `TicketList` | جدول تذاكر مُرقّم |
+| `ReplyThread` | عرض الردود بترتيب زمني |
+| `ReplyComposer` | محرر الرد/الملاحظة مع رفع الملفات وإدراج الردود الجاهزة |
+| `ActivityTimeline` | سجل تدقيق لأحداث التذكرة |
+| `SlaTimer` | عد تنازلي SLA مع حالات الانتهاك/التحذير |
+| `TicketFilters` | شريط تصفية الحالة والأولوية والوكيل والقسم |
+| `TicketSidebar` | الشريط الجانبي لتفاصيل التذكرة (الحالة، SLA، العلامات، النشاط) |
+| `AssigneeSelect` | قائمة منسدلة لتعيين الوكيل |
+| `TagSelect` | منتقي علامات متعدد الاختيار |
+| `FileDropzone` | رفع ملفات بالسحب والإفلات |
+| `AttachmentList` | عرض مرفقات الملفات مع روابط التحميل |
+| `StatsCard` | بطاقة مقاييس مع تسمية وقيمة واتجاه |
+| `EscalatedLayout` | تخطيط المستوى الأعلى مع التنقل (يدعم حقن تخطيط المضيف) |
+| `BulkActionBar` | شريط أدوات للعمليات المجمعة على التذاكر المحددة |
+| `QuickFilters` | رقاقات تصفية بنقرة واحدة (تذاكري، غير معيّنة، عاجلة، SLA منتهكة) |
+| `MacroDropdown` | قائمة منسدلة لتطبيق وحدات ماكرو متعددة الخطوات على تذكرة |
+| `FollowButton` | زر تبديل لمتابعة/إلغاء متابعة تذكرة |
+| `SatisfactionRating` | إدخال تقييم CSAT من 1-5 نجوم مع تعليق اختياري |
+| `KeyboardShortcutHelp` | نافذة منبثقة تعرض جميع اختصارات لوحة المفاتيح المتاحة |
+| `PinnedNotes` | عرض الملاحظات الداخلية المثبتة في أعلى السلسلة |
+| `PresenceIndicator` | مؤشر فوري يعرض من يشاهد التذكرة |
+
+### التركيبات (Composables)
+
+| التركيب | الوصف |
+|------------|-------------|
+| `useKeyboardShortcuts` | يسجل ويدير اختصارات لوحة المفاتيح لإجراءات التذاكر |
+
+### الإضافة
+
+| التصدير | الوصف |
+|--------|-------------|
+| `EscalatedPlugin` | إضافة Vue لحقن التخطيط وتخصيص CSS |
+
+## تطوير الإضافات
+
+يدعم Escalated الإضافات المستقلة عن إطار العمل المبنية باستخدام [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). تُكتب الإضافات مرة واحدة بـ TypeScript وتعمل عبر جميع واجهات Escalated الخلفية.
+
+### كيف يعمل نظام إضافات الواجهة الأمامية
+
+تستخدم الواجهة الأمامية `defineEscalatedPlugin()` لتسجيل مكونات Vue — صفحات مسؤول مخصصة أو أدوات الشريط الجانبي للتذاكر أو لوحات لوحة المعلومات — التي يتم تركيبها تلقائياً عندما تكون الإضافة نشطة.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### كيف تتصل بالواجهة الخلفية
+
+تستخدم الواجهة الخلفية `definePlugin()` من [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) للتعامل مع منطق TypeScript للأعمال — الاشتراك في خطافات دورة حياة التذاكر وكشف نقاط نهاية API واستمرار البيانات. تعمل إدخالات الواجهة الأمامية والخلفية معاً كحزمة npm واحدة.
+
+```typescript
+// إدخال الواجهة الخلفية (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### مثال سريع: كلا نقطتي الدخول
+
+تصدر حزمة الإضافة المنشورة عادةً كليهما:
+
+```
+my-plugin/
+  index.ts          ← الواجهة الخلفية: definePlugin() لمنطق TypeScript
+  frontend.ts       ← الواجهة الأمامية: defineEscalatedPlugin() لمكونات Vue
+```
+
+يحمّل إطار العمل الخلفي (Laravel، Rails، Django، AdonisJS) `index.ts` عبر [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). يستورد تطبيق Vue `frontend.ts` ويسجله مع `app.use()`.
+
+### تثبيت الإضافات
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### الموارد
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK لبناء الإضافات
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — مضيف وقت التشغيل للإضافات
+- [دليل تطوير الإضافات](https://github.com/escalated-dev/escalated-docs) — التوثيق الكامل
+
+## لمشرفي الحزم
+
+إذا كنت تبني تكاملاً خلفياً جديداً، فهذه الحزمة متوفرة على npm:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// استيراد الإضافة
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// استيراد مكونات فردية
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// أو الإشارة إلى الصفحات مباشرة لحل Inertia
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+التبعيات المتناظرة: `vue` ^3.3.0، `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## المنظومة
+
+هذه هي الواجهة الأمامية المشتركة لنظام تذاكر دعم Escalated. حزم الواجهة الخلفية متوفرة لكل إطار عمل رئيسي:
+
+- **[Escalated لـ Laravel](https://github.com/escalated-dev/escalated-laravel)** — حزمة Laravel Composer
+- **[Escalated لـ Rails](https://github.com/escalated-dev/escalated-rails)** — محرك Ruby on Rails
+- **[Escalated لـ Django](https://github.com/escalated-dev/escalated-django)** — تطبيق Django قابل لإعادة الاستخدام
+- **[Escalated لـ AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — حزمة AdonisJS v6
+- **[Escalated لـ Filament](https://github.com/escalated-dev/escalated-filament)** — إضافة لوحة مسؤول Filament v3
+- **[الواجهة الأمامية المشتركة](https://github.com/escalated-dev/escalated)** — مكونات Vue 3 + Inertia.js (أنت هنا)
+
+## الرخصة
+
+MIT

--- a/docs/translations/README.de.md
+++ b/docs/translations/README.de.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <b>Deutsch</b> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated ist ein einbettbares Support-Ticket-System mit SLA-Tracking, Eskalationsregeln, Agenten-Workflows und einem Kundenportal. Dieses Repository enthält alle gemeinsamen Frontend-Assets (Vue 3 + Inertia.js), die in allen unterstützten Backend-Frameworks verwendet werden.
+
+👉 **Erfahren Sie mehr, sehen Sie Demos und vergleichen Sie Cloud- und Self-Hosted-Optionen auf** **[https://escalated.dev](https://escalated.dev)**
+
+**Installieren Sie dieses Paket nicht direkt.** Beginnen Sie mit dem Backend-Paket für Ihr Framework — es kümmert sich um alles, einschließlich des Einbindens dieser Frontend-Assets.
+
+## Funktionen
+
+- **Ticket-Aufspaltung** — Spalten Sie eine Antwort in ein neues eigenständiges Ticket auf und bewahren Sie den Kontext
+- **Ticket-Schlummerfunktion** — Schlummern Sie Tickets mit Voreinstellungen (1h, 4h, morgen, nächste Woche) und automatischem Aufwachen
+- **Gespeicherte Ansichten / Benutzerdefinierte Warteschlangen** — Speichern, benennen und teilen Sie Filtervoreinstellungen als wiederverwendbare Ticket-Ansichten
+- **Einbettbares Support-Widget** — Sofort einsetzbares `<script>`-Widget mit KB-Suche, Ticket-Formular und Statusprüfung
+- **Echtzeit-Updates** — WebSocket-Unterstützung (Pusher/Reverb/Soketi) mit automatischem Polling-Fallback
+- **Wissensdatenbank-Umschalter** — Aktivieren oder deaktivieren Sie die öffentliche Wissensdatenbank in den Admin-Einstellungen
+- **CI: ESLint + Prettier** — Automatische Code-Stil-Durchsetzung bei jedem Pull Request
+
+## Erste Schritte
+
+Wählen Sie Ihr Framework:
+
+| Framework | Repository | Installation |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [escalated.zip herunterladen](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Siehe [pubspec.yaml-Einrichtung](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Jedes Backend-Repository enthält vollständige Einrichtungsanweisungen — Installationsbefehl, Migrationen, Konfiguration und Frontend-Integration.
+
+## Tailwind CSS
+
+Escalated-Komponenten verwenden Tailwind-CSS-Klassen. Sie **müssen** dieses Paket zu Ihrer Tailwind-`content`-Konfiguration hinzufügen, damit seine Klassen nicht entfernt werden:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... Ihre vorhandenen Pfade
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Ohne dies wird die Escalated-Benutzeroberfläche gerendert, aber Stile wie Schaltflächenhintergründe und Badge-Farben fehlen.
+
+## Theming
+
+Escalated wird standardmäßig in einem eigenständigen Layout gerendert. Um es in das Design-System Ihrer App zu integrieren, verwenden Sie das `EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Layout-Integration
+
+Übergeben Sie die Layout-Komponente Ihrer App und alle Escalated-Seiten werden automatisch darin gerendert. Die Layout-Komponente muss einen `#header`-Slot und einen Standard-Slot akzeptieren:
+
+```vue
+<!-- Ihr Layout muss diese Slots unterstützen -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Wenn kein Layout angegeben wird, verwendet Escalated seine eigene integrierte Navigationsleiste.
+
+### Benutzerdefinierte CSS-Eigenschaften
+
+Die `theme`-Option setzt benutzerdefinierte CSS-Eigenschaften, die Sie in Ihren eigenen Stilen referenzieren können:
+
+| Eigenschaft | Standard | Beschreibung |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Primäre Aktionsfarbe |
+| `--esc-primary-hover` | automatisch abgedunkelt | Primäre Hover-Farbe |
+| `--esc-radius` | `0.5rem` | Rahmenradius für Eingaben und Schaltflächen |
+| `--esc-radius-lg` | automatisch skaliert | Rahmenradius für Karten und Panels |
+| `--esc-font-family` | vererbt | Schriftfamilien-Überschreibung |
+
+### Framework-Beispiele
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Was in diesem Repository enthalten ist
+
+Alle Vue 3 + Inertia.js-Komponenten, die die Escalated-Benutzeroberfläche antreiben. Diese sind identisch über Laravel, Rails, Django und AdonisJS hinweg — das Backend-Framework rendert sie über Inertia.
+
+## 📸 Screenshots
+
+> Screenshots werden automatisch aus Storybook über den [component-screenshots](.github/workflows/screenshots.yml)-Workflow generiert.
+
+<p align="center">
+  <strong>Admin-Panel (Dunkel)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Escalated Admin-Panel — Dunkelmodus mit Seitenleisten-Navigation, KPI-Karten, Statistiken und Ticket-Liste" width="800" />
+</p>
+
+<p align="center">
+  <strong>Admin-Panel (Hell)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Escalated Admin-Panel — Hellmodus mit Seitenleisten-Navigation, KPI-Karten, Statistiken und Ticket-Liste" width="800" />
+</p>
+
+<p align="center">
+  <strong>Ticket-Warteschlange</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Escalated Ticket-Warteschlange — Agenten-Ticketliste mit Filtern, Suche, Massenaktionen und SLA-Indikatoren" width="800" />
+</p>
+
+<p align="center">
+  <strong>Agenten-Panel</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Escalated Agenten-Panel — obere Navigation, Statistiken und zugewiesene Ticket-Warteschlange" width="800" />
+</p>
+
+<p align="center">
+  <strong>Ticket-Detailansicht</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Escalated Ticket-Detailansicht — Konversationsthread, Antwort-Editor und Ticket-Seitenleiste mit SLA-Timer" width="800" />
+</p>
+
+### Seiten
+
+**Kundenportal** — Self-Service-Ticketverwaltung
+- `pages/Customer/Index.vue` — Ticketliste mit Statusfiltern und Suche
+- `pages/Customer/Create.vue` — Neues Ticketformular mit Dateianhängen
+- `pages/Customer/Show.vue` — Ticketdetail mit Antwortthread
+
+**Agenten-Dashboard** — Ticket-Warteschlange und Workflows
+- `pages/Agent/Dashboard.vue` — Statistikübersicht und neueste Tickets
+- `pages/Agent/TicketIndex.vue` — Filterbare Ticket-Warteschlange
+- `pages/Agent/TicketShow.vue` — Vollständige Ticketansicht mit Seitenleiste, internen Notizen, vorgefertigten Antworten
+
+**Admin-Panel** — Systemkonfiguration
+- `pages/Admin/Reports.vue` — Analyse-Dashboard
+- `pages/Admin/Departments/` — Abteilungsverwaltung
+- `pages/Admin/SlaPolicies/` — SLA-Richtlinienverwaltung
+- `pages/Admin/EscalationRules/` — Eskalationsregel-Builder
+- `pages/Admin/Tags/` — Tag-Verwaltung
+- `pages/Admin/CannedResponses/` — Vorgefertigte Antwortvorlagen
+
+### Gemeinsame Komponenten
+
+Wiederverwendbare Bausteine, die auf den obigen Seiten verwendet werden.
+
+| Komponente | Beschreibung |
+|-----------|-------------|
+| `StatusBadge` | Farbiges Badge für Ticket-Status |
+| `PriorityBadge` | Farbiges Badge für Ticket-Priorität |
+| `TicketList` | Paginierte Ticket-Tabelle |
+| `ReplyThread` | Chronologische Antwortanzeige |
+| `ReplyComposer` | Antwort-/Notiz-Editor mit Datei-Upload und Einfügen vorgefertigter Antworten |
+| `ActivityTimeline` | Prüfprotokoll der Ticket-Ereignisse |
+| `SlaTimer` | SLA-Countdown mit Verletzungs-/Warnzuständen |
+| `TicketFilters` | Filter-Leiste für Status, Priorität, Agent, Abteilung |
+| `TicketSidebar` | Ticket-Detail-Seitenleiste (Status, SLA, Tags, Aktivität) |
+| `AssigneeSelect` | Dropdown für Agentenzuweisung |
+| `TagSelect` | Mehrfachauswahl-Tag-Picker |
+| `FileDropzone` | Drag-and-Drop-Datei-Upload |
+| `AttachmentList` | Dateianhang-Anzeige mit Download-Links |
+| `StatsCard` | Metrikkarte mit Bezeichnung, Wert und Trend |
+| `EscalatedLayout` | Top-Level-Layout mit Navigation (unterstützt Host-Layout-Injection) |
+| `BulkActionBar` | Werkzeugleiste für Massenoperationen auf ausgewählten Tickets |
+| `QuickFilters` | Ein-Klick-Filter-Chips (Meine Tickets, Nicht zugewiesen, Dringend, SLA-Verletzung) |
+| `MacroDropdown` | Dropdown zum Anwenden mehrstufiger Makros auf ein Ticket |
+| `FollowButton` | Umschaltknopf zum Folgen/Entfolgen eines Tickets |
+| `SatisfactionRating` | 1-5 Sterne CSAT-Bewertungseingabe mit optionalem Kommentar |
+| `KeyboardShortcutHelp` | Modal-Overlay mit allen verfügbaren Tastenkombinationen |
+| `PinnedNotes` | Anzeige angehefteter interner Notizen oben im Thread |
+| `PresenceIndicator` | Echtzeit-Indikator, der zeigt, wer ein Ticket ansieht |
+
+### Composables
+
+| Composable | Beschreibung |
+|------------|-------------|
+| `useKeyboardShortcuts` | Registriert und verwaltet Tastenkombinationen für Ticket-Aktionen |
+
+### Plugin
+
+| Export | Beschreibung |
+|--------|-------------|
+| `EscalatedPlugin` | Vue-Plugin für Layout-Injection und CSS-Theming |
+
+## Plugin-Entwicklung
+
+Escalated unterstützt framework-unabhängige Plugins, die mit dem [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) erstellt werden. Plugins werden einmal in TypeScript geschrieben und funktionieren auf allen Escalated-Backends.
+
+### Wie das Frontend-Plugin-System funktioniert
+
+Das Frontend verwendet `defineEscalatedPlugin()`, um Vue-Komponenten zu registrieren — benutzerdefinierte Admin-Seiten, Ticket-Seitenleisten-Widgets oder Dashboard-Panels — die automatisch gemountet werden, wenn das Plugin aktiv ist.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Wie es sich mit dem Backend verbindet
+
+Das Backend verwendet `definePlugin()` aus dem [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk), um die TypeScript-Geschäftslogik zu handhaben — Ticket-Lebenszyklus-Hooks abonnieren, API-Endpunkte bereitstellen und Daten persistieren. Die Frontend- und Backend-Einträge arbeiten als ein einziges npm-Paket zusammen.
+
+```typescript
+// Backend-Eintrag (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Schnellbeispiel: Beide Einstiegspunkte
+
+Ein veröffentlichtes Plugin-Paket exportiert typischerweise beides:
+
+```
+my-plugin/
+  index.ts          ← Backend: definePlugin() für TypeScript-Logik
+  frontend.ts       ← Frontend: defineEscalatedPlugin() für Vue-Komponenten
+```
+
+Das Backend-Framework (Laravel, Rails, Django, AdonisJS) lädt `index.ts` über die [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). Die Vue-App importiert `frontend.ts` und registriert es mit `app.use()`.
+
+### Plugins installieren
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Ressourcen
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript-SDK zum Erstellen von Plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Laufzeit-Host für Plugins
+- [Plugin-Entwicklungshandbuch](https://github.com/escalated-dev/escalated-docs) — Vollständige Dokumentation
+
+## Für Paket-Maintainer
+
+Wenn Sie eine neue Backend-Integration erstellen, ist dieses Paket auf npm verfügbar:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Plugin importieren
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Einzelne Komponenten importieren
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// Oder Seiten direkt für die Inertia-Auflösung referenzieren
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Peer-Abhängigkeiten: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ökosystem
+
+Dies ist das gemeinsame Frontend für das Escalated-Support-Ticket-System. Backend-Pakete sind für jedes große Framework verfügbar:
+
+- **[Escalated für Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer-Paket
+- **[Escalated für Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails Engine
+- **[Escalated für Django](https://github.com/escalated-dev/escalated-django)** — Wiederverwendbare Django-App
+- **[Escalated für AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6-Paket
+- **[Escalated für Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 Admin-Panel-Plugin
+- **[Gemeinsames Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI-Komponenten (Sie sind hier)
+
+## Lizenz
+
+MIT

--- a/docs/translations/README.es.md
+++ b/docs/translations/README.es.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <b>Español</b> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated es un sistema de tickets de soporte integrable con seguimiento de SLA, reglas de escalamiento, flujos de trabajo para agentes y un portal de clientes. Este repositorio contiene todos los recursos frontend compartidos (Vue 3 + Inertia.js) utilizados en todos los frameworks backend soportados.
+
+👉 **Aprenda más, vea demos y compare las opciones de Nube vs Auto-hospedado en** **[https://escalated.dev](https://escalated.dev)**
+
+**No instale este paquete directamente.** Comience con el paquete backend para su framework — se encarga de todo, incluyendo la incorporación de estos recursos frontend.
+
+## Características
+
+- **División de tickets** — Divida una respuesta en un nuevo ticket independiente preservando el contexto
+- **Posponer tickets** — Posponga tickets con preajustes (1h, 4h, mañana, próxima semana) y activación automática
+- **Vistas guardadas / colas personalizadas** — Guarde, nombre y comparta preajustes de filtros como vistas de tickets reutilizables
+- **Widget de soporte integrable** — Widget `<script>` listo para usar con búsqueda en KB, formulario de tickets y verificación de estado
+- **Actualizaciones en tiempo real** — Soporte WebSocket (Pusher/Reverb/Soketi) con respaldo de sondeo automático
+- **Interruptor de base de conocimiento** — Active o desactive la base de conocimiento pública desde la configuración de administrador
+- **CI: ESLint + Prettier** — Aplicación automática de estilo de código en cada pull request
+
+## Primeros Pasos
+
+Elija su framework:
+
+| Framework | Repositorio | Instalación |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [Descargar escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Ver [configuración de pubspec.yaml](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Cada repositorio backend tiene instrucciones de configuración completas — comando de instalación, migraciones, configuración e integración frontend.
+
+## Tailwind CSS
+
+Los componentes de Escalated usan clases de Tailwind CSS. **Debe** agregar este paquete a la configuración `content` de Tailwind para que sus clases no sean purgadas:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... sus rutas existentes
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Sin esto, la interfaz de Escalated se renderizará pero los estilos como fondos de botones y colores de insignias estarán ausentes.
+
+## Personalización
+
+Escalated se renderiza dentro de un layout independiente por defecto. Para integrarlo en el sistema de diseño de su aplicación, use el `EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Integración de Layout
+
+Pase el componente de layout de su aplicación y todas las páginas de Escalated se renderizarán dentro de él automáticamente. El componente de layout debe aceptar un slot `#header` y un slot predeterminado:
+
+```vue
+<!-- Su layout debe soportar estos slots -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Cuando no se proporciona un layout, Escalated usa su propia barra de navegación integrada.
+
+### Propiedades CSS Personalizadas
+
+La opción `theme` establece propiedades CSS personalizadas que puede referenciar en sus propios estilos:
+
+| Propiedad | Predeterminado | Descripción |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Color de acción primaria |
+| `--esc-primary-hover` | oscurecido automáticamente | Color primario al pasar el cursor |
+| `--esc-radius` | `0.5rem` | Radio de borde para entradas y botones |
+| `--esc-radius-lg` | escalado automáticamente | Radio de borde para tarjetas y paneles |
+| `--esc-font-family` | heredado | Sobrescritura de familia de fuentes |
+
+### Ejemplos por Framework
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Qué Hay en Este Repositorio
+
+Todos los componentes Vue 3 + Inertia.js que impulsan la interfaz de Escalated. Estos son idénticos en Laravel, Rails, Django y AdonisJS — el framework backend los renderiza a través de Inertia.
+
+## 📸 Capturas de Pantalla
+
+> Las capturas de pantalla se generan automáticamente desde Storybook a través del flujo de trabajo [component-screenshots](.github/workflows/screenshots.yml).
+
+<p align="center">
+  <strong>Panel de Administración (Oscuro)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Panel de administración de Escalated — modo oscuro con navegación lateral, tarjetas KPI, estadísticas y lista de tickets" width="800" />
+</p>
+
+<p align="center">
+  <strong>Panel de Administración (Claro)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Panel de administración de Escalated — modo claro con navegación lateral, tarjetas KPI, estadísticas y lista de tickets" width="800" />
+</p>
+
+<p align="center">
+  <strong>Cola de Tickets</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Cola de tickets de Escalated — lista de tickets del agente con filtros, búsqueda, acciones masivas e indicadores SLA" width="800" />
+</p>
+
+<p align="center">
+  <strong>Panel del Agente</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Panel del agente de Escalated — navegación superior, estadísticas y cola de tickets asignados" width="800" />
+</p>
+
+<p align="center">
+  <strong>Vista de Detalle del Ticket</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Vista de detalle del ticket de Escalated — hilo de conversación, editor de respuesta y barra lateral del ticket con temporizador SLA" width="800" />
+</p>
+
+### Páginas
+
+**Portal del Cliente** — Gestión de tickets de autoservicio
+- `pages/Customer/Index.vue` — Lista de tickets con filtros de estado y búsqueda
+- `pages/Customer/Create.vue` — Formulario de nuevo ticket con archivos adjuntos
+- `pages/Customer/Show.vue` — Detalle del ticket con hilo de respuestas
+
+**Panel del Agente** — Cola de tickets y flujos de trabajo
+- `pages/Agent/Dashboard.vue` — Resumen de estadísticas y tickets recientes
+- `pages/Agent/TicketIndex.vue` — Cola de tickets filtrable
+- `pages/Agent/TicketShow.vue` — Vista completa del ticket con barra lateral, notas internas, respuestas predefinidas
+
+**Panel de Administración** — Configuración del sistema
+- `pages/Admin/Reports.vue` — Panel de análisis
+- `pages/Admin/Departments/` — Gestión de departamentos (CRUD)
+- `pages/Admin/SlaPolicies/` — Gestión de políticas SLA
+- `pages/Admin/EscalationRules/` — Constructor de reglas de escalamiento
+- `pages/Admin/Tags/` — Gestión de etiquetas
+- `pages/Admin/CannedResponses/` — Plantillas de respuestas predefinidas
+
+### Componentes Compartidos
+
+Bloques de construcción reutilizables utilizados en las páginas anteriores.
+
+| Componente | Descripción |
+|-----------|-------------|
+| `StatusBadge` | Insignia de color para el estado del ticket |
+| `PriorityBadge` | Insignia de color para la prioridad del ticket |
+| `TicketList` | Tabla de tickets paginada |
+| `ReplyThread` | Visualización cronológica de respuestas |
+| `ReplyComposer` | Editor de respuesta/nota con carga de archivos e inserción de respuestas predefinidas |
+| `ActivityTimeline` | Registro de auditoría de eventos del ticket |
+| `SlaTimer` | Cuenta regresiva SLA con estados de violación/advertencia |
+| `TicketFilters` | Barra de filtros de estado, prioridad, agente, departamento |
+| `TicketSidebar` | Barra lateral de detalle del ticket (estado, SLA, etiquetas, actividad) |
+| `AssigneeSelect` | Desplegable de asignación de agente |
+| `TagSelect` | Selector de etiquetas de selección múltiple |
+| `FileDropzone` | Carga de archivos con arrastrar y soltar |
+| `AttachmentList` | Visualización de archivos adjuntos con enlaces de descarga |
+| `StatsCard` | Tarjeta de métricas con etiqueta, valor y tendencia |
+| `EscalatedLayout` | Layout de nivel superior con navegación (soporta inyección de layout del host) |
+| `BulkActionBar` | Barra de herramientas para operaciones masivas en tickets seleccionados |
+| `QuickFilters` | Chips de filtro de un clic (Mis Tickets, Sin Asignar, Urgente, SLA Violado) |
+| `MacroDropdown` | Desplegable para aplicar macros de múltiples pasos a un ticket |
+| `FollowButton` | Botón de alternancia para seguir/dejar de seguir un ticket |
+| `SatisfactionRating` | Entrada de calificación CSAT de 1-5 estrellas con comentario opcional |
+| `KeyboardShortcutHelp` | Superposición modal mostrando todos los atajos de teclado disponibles |
+| `PinnedNotes` | Mostrar notas internas fijadas en la parte superior del hilo |
+| `PresenceIndicator` | Indicador en tiempo real que muestra quién está viendo un ticket |
+
+### Composables
+
+| Composable | Descripción |
+|------------|-------------|
+| `useKeyboardShortcuts` | Registra y gestiona atajos de teclado para acciones de tickets |
+
+### Plugin
+
+| Exportación | Descripción |
+|--------|-------------|
+| `EscalatedPlugin` | Plugin Vue para inyección de layout y personalización CSS |
+
+## Desarrollo de Plugins
+
+Escalated soporta plugins agnósticos al framework construidos con el [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Los plugins se escriben una vez en TypeScript y funcionan en todos los backends de Escalated.
+
+### Cómo Funciona el Sistema de Plugins del Frontend
+
+El frontend usa `defineEscalatedPlugin()` para registrar componentes Vue — páginas de administración personalizadas, widgets de barra lateral de tickets o paneles de dashboard — que se montan automáticamente cuando el plugin está activo.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Cómo se Conecta al Backend
+
+El backend usa `definePlugin()` del [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) para manejar la lógica de negocios en TypeScript — suscribirse a hooks del ciclo de vida de tickets, exponer endpoints API y persistir datos. Las entradas del frontend y backend trabajan juntas como un solo paquete npm.
+
+```typescript
+// entrada del backend (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Ejemplo Rápido: Ambos Puntos de Entrada
+
+Un paquete de plugin publicado típicamente exporta ambos:
+
+```
+my-plugin/
+  index.ts          ← backend: definePlugin() para lógica TypeScript
+  frontend.ts       ← frontend: defineEscalatedPlugin() para componentes Vue
+```
+
+El framework backend (Laravel, Rails, Django, AdonisJS) carga `index.ts` a través del [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). La aplicación Vue importa `frontend.ts` y lo registra con `app.use()`.
+
+### Instalación de Plugins
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Recursos
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK TypeScript para construir plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host de tiempo de ejecución para plugins
+- [Guía de Desarrollo de Plugins](https://github.com/escalated-dev/escalated-docs) — Documentación completa
+
+## Para Mantenedores de Paquetes
+
+Si está construyendo una nueva integración backend, este paquete está disponible en npm:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Importar el plugin
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Importar componentes individuales
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// O referenciar páginas directamente para la resolución de Inertia
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Dependencias peer: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ecosistema
+
+Este es el frontend compartido para el sistema de tickets de soporte Escalated. Paquetes backend disponibles para cada framework principal:
+
+- **[Escalated para Laravel](https://github.com/escalated-dev/escalated-laravel)** — Paquete Laravel Composer
+- **[Escalated para Rails](https://github.com/escalated-dev/escalated-rails)** — Motor Ruby on Rails
+- **[Escalated para Django](https://github.com/escalated-dev/escalated-django)** — Aplicación reutilizable Django
+- **[Escalated para AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Paquete AdonisJS v6
+- **[Escalated para Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin de panel de administración Filament v3
+- **[Frontend Compartido](https://github.com/escalated-dev/escalated)** — Componentes UI Vue 3 + Inertia.js (usted está aquí)
+
+## Licencia
+
+MIT

--- a/docs/translations/README.fr.md
+++ b/docs/translations/README.fr.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <b>Français</b> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated est un systeme de tickets de support integrable avec suivi des SLA, regles d'escalade, workflows pour agents et portail client. Ce depot contient tous les assets frontend partages (Vue 3 + Inertia.js) utilises dans tous les frameworks backend supportes.
+
+👉 **En savoir plus, voir les demos et comparer les options Cloud vs Auto-heberge sur** **[https://escalated.dev](https://escalated.dev)**
+
+**N'installez pas ce paquet directement.** Commencez par le paquet backend pour votre framework — il gere tout, y compris l'integration de ces assets frontend.
+
+## Fonctionnalites
+
+- **Division de tickets** — Divisez une reponse en un nouveau ticket independant tout en preservant le contexte
+- **Mise en veille de tickets** — Mettez en veille les tickets avec des preselections (1h, 4h, demain, semaine prochaine) et reveil automatique
+- **Vues enregistrees / files d'attente personnalisees** — Enregistrez, nommez et partagez des preselections de filtres comme vues de tickets reutilisables
+- **Widget de support integrable** — Widget `<script>` pret a l'emploi avec recherche KB, formulaire de ticket et verification de statut
+- **Mises a jour en temps reel** — Support WebSocket (Pusher/Reverb/Soketi) avec repli de sondage automatique
+- **Basculement de la base de connaissances** — Activez ou desactivez la base de connaissances publique depuis les parametres d'administration
+- **CI : ESLint + Prettier** — Application automatique du style de code a chaque pull request
+
+## Pour Commencer
+
+Choisissez votre framework :
+
+| Framework | Depot | Installation |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [Telecharger escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Voir [configuration pubspec.yaml](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Chaque depot backend contient des instructions de configuration completes — commande d'installation, migrations, configuration et integration frontend.
+
+## Tailwind CSS
+
+Les composants Escalated utilisent des classes Tailwind CSS. Vous **devez** ajouter ce paquet a votre configuration `content` de Tailwind pour que ses classes ne soient pas purgees :
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... vos chemins existants
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Sans cela, l'interface Escalated sera rendue mais les styles comme les arriere-plans de boutons et les couleurs de badges seront absents.
+
+## Personnalisation
+
+Escalated s'affiche dans un layout autonome par defaut. Pour l'integrer dans le systeme de design de votre application, utilisez le `EscalatedPlugin` :
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Integration du Layout
+
+Passez le composant de layout de votre application et toutes les pages Escalated s'afficheront automatiquement a l'interieur. Le composant de layout doit accepter un slot `#header` et un slot par defaut :
+
+```vue
+<!-- Votre layout doit supporter ces slots -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Lorsqu'aucun layout n'est fourni, Escalated utilise sa propre barre de navigation integree.
+
+### Proprietes CSS Personnalisees
+
+L'option `theme` definit des proprietes CSS personnalisees que vous pouvez referencer dans vos propres styles :
+
+| Propriete | Par defaut | Description |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Couleur d'action principale |
+| `--esc-primary-hover` | assombrissement automatique | Couleur de survol principale |
+| `--esc-radius` | `0.5rem` | Rayon de bordure pour les champs et boutons |
+| `--esc-radius-lg` | mise a l'echelle automatique | Rayon de bordure pour les cartes et panneaux |
+| `--esc-font-family` | herite | Remplacement de la famille de polices |
+
+### Exemples par Framework
+
+**Laravel** (Inertia + Vue 3) :
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3) :
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3) :
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3) :
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Contenu de ce Depot
+
+Tous les composants Vue 3 + Inertia.js qui alimentent l'interface Escalated. Ceux-ci sont identiques sur Laravel, Rails, Django et AdonisJS — le framework backend les rend via Inertia.
+
+## 📸 Captures d'ecran
+
+> Les captures d'ecran sont generees automatiquement depuis Storybook via le workflow [component-screenshots](.github/workflows/screenshots.yml).
+
+<p align="center">
+  <strong>Panneau d'Administration (Sombre)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Panneau d'administration Escalated — mode sombre avec navigation laterale, cartes KPI, statistiques et liste de tickets" width="800" />
+</p>
+
+<p align="center">
+  <strong>Panneau d'Administration (Clair)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Panneau d'administration Escalated — mode clair avec navigation laterale, cartes KPI, statistiques et liste de tickets" width="800" />
+</p>
+
+<p align="center">
+  <strong>File d'Attente des Tickets</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="File d'attente des tickets Escalated — liste de tickets de l'agent avec filtres, recherche, actions groupees et indicateurs SLA" width="800" />
+</p>
+
+<p align="center">
+  <strong>Panneau de l'Agent</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Panneau de l'agent Escalated — navigation superieure, statistiques et file d'attente des tickets assignes" width="800" />
+</p>
+
+<p align="center">
+  <strong>Vue Detail du Ticket</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Vue detail du ticket Escalated — fil de conversation, editeur de reponse et barre laterale du ticket avec minuteur SLA" width="800" />
+</p>
+
+### Pages
+
+**Portail Client** — Gestion des tickets en libre-service
+- `pages/Customer/Index.vue` — Liste de tickets avec filtres de statut et recherche
+- `pages/Customer/Create.vue` — Formulaire de nouveau ticket avec pieces jointes
+- `pages/Customer/Show.vue` — Detail du ticket avec fil de reponses
+
+**Tableau de Bord de l'Agent** — File d'attente des tickets et workflows
+- `pages/Agent/Dashboard.vue` — Vue d'ensemble des statistiques et tickets recents
+- `pages/Agent/TicketIndex.vue` — File d'attente de tickets filtrable
+- `pages/Agent/TicketShow.vue` — Vue complete du ticket avec barre laterale, notes internes, reponses predefinies
+
+**Panneau d'Administration** — Configuration du systeme
+- `pages/Admin/Reports.vue` — Tableau de bord analytique
+- `pages/Admin/Departments/` — Gestion des departements (CRUD)
+- `pages/Admin/SlaPolicies/` — Gestion des politiques SLA
+- `pages/Admin/EscalationRules/` — Constructeur de regles d'escalade
+- `pages/Admin/Tags/` — Gestion des etiquettes
+- `pages/Admin/CannedResponses/` — Modeles de reponses predefinies
+
+### Composants Partages
+
+Blocs de construction reutilisables utilises dans les pages ci-dessus.
+
+| Composant | Description |
+|-----------|-------------|
+| `StatusBadge` | Badge colore pour le statut du ticket |
+| `PriorityBadge` | Badge colore pour la priorite du ticket |
+| `TicketList` | Tableau de tickets pagine |
+| `ReplyThread` | Affichage chronologique des reponses |
+| `ReplyComposer` | Editeur de reponse/note avec upload de fichiers et insertion de reponses predefinies |
+| `ActivityTimeline` | Journal d'audit des evenements du ticket |
+| `SlaTimer` | Compte a rebours SLA avec etats de violation/avertissement |
+| `TicketFilters` | Barre de filtres statut, priorite, agent, departement |
+| `TicketSidebar` | Barre laterale de detail du ticket (statut, SLA, etiquettes, activite) |
+| `AssigneeSelect` | Menu deroulant d'assignation d'agent |
+| `TagSelect` | Selecteur d'etiquettes a selection multiple |
+| `FileDropzone` | Upload de fichiers par glisser-deposer |
+| `AttachmentList` | Affichage des pieces jointes avec liens de telechargement |
+| `StatsCard` | Carte de metriques avec libelle, valeur et tendance |
+| `EscalatedLayout` | Layout de niveau superieur avec navigation (supporte l'injection de layout hote) |
+| `BulkActionBar` | Barre d'outils pour les operations groupees sur les tickets selectionnes |
+| `QuickFilters` | Puces de filtre en un clic (Mes Tickets, Non Assignes, Urgent, SLA Viole) |
+| `MacroDropdown` | Menu deroulant pour appliquer des macros multi-etapes a un ticket |
+| `FollowButton` | Bouton bascule pour suivre/ne plus suivre un ticket |
+| `SatisfactionRating` | Saisie de note CSAT de 1 a 5 etoiles avec commentaire optionnel |
+| `KeyboardShortcutHelp` | Superposition modale affichant tous les raccourcis clavier disponibles |
+| `PinnedNotes` | Affichage des notes internes epinglees en haut du fil |
+| `PresenceIndicator` | Indicateur en temps reel montrant qui consulte un ticket |
+
+### Composables
+
+| Composable | Description |
+|------------|-------------|
+| `useKeyboardShortcuts` | Enregistre et gere les raccourcis clavier pour les actions sur les tickets |
+
+### Plugin
+
+| Export | Description |
+|--------|-------------|
+| `EscalatedPlugin` | Plugin Vue pour l'injection de layout et la personnalisation CSS |
+
+## Developpement de Plugins
+
+Escalated supporte les plugins independants du framework construits avec le [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Les plugins sont ecrits une fois en TypeScript et fonctionnent sur tous les backends Escalated.
+
+### Comment Fonctionne le Systeme de Plugins Frontend
+
+Le frontend utilise `defineEscalatedPlugin()` pour enregistrer des composants Vue — pages d'administration personnalisees, widgets de barre laterale de tickets ou panneaux de tableau de bord — qui sont montes automatiquement lorsque le plugin est actif.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Comment il se Connecte au Backend
+
+Le backend utilise `definePlugin()` du [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) pour gerer la logique metier TypeScript — s'abonner aux hooks du cycle de vie des tickets, exposer des endpoints API et persister les donnees. Les entrees frontend et backend fonctionnent ensemble comme un seul paquet npm.
+
+```typescript
+// entree backend (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Exemple Rapide : Les Deux Points d'Entree
+
+Un paquet de plugin publie exporte typiquement les deux :
+
+```
+my-plugin/
+  index.ts          ← backend : definePlugin() pour la logique TypeScript
+  frontend.ts       ← frontend : defineEscalatedPlugin() pour les composants Vue
+```
+
+Le framework backend (Laravel, Rails, Django, AdonisJS) charge `index.ts` via le [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). L'application Vue importe `frontend.ts` et l'enregistre avec `app.use()`.
+
+### Installation des Plugins
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Ressources
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK TypeScript pour construire des plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Hote d'execution pour les plugins
+- [Guide de Developpement de Plugins](https://github.com/escalated-dev/escalated-docs) — Documentation complete
+
+## Pour les Mainteneurs de Paquets
+
+Si vous construisez une nouvelle integration backend, ce paquet est disponible sur npm :
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Importer le plugin
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Importer des composants individuels
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// Ou referencer les pages directement pour la resolution Inertia
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Dependances peer : `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ecosysteme
+
+Ceci est le frontend partage pour le systeme de tickets de support Escalated. Paquets backend disponibles pour chaque framework majeur :
+
+- **[Escalated pour Laravel](https://github.com/escalated-dev/escalated-laravel)** — Paquet Laravel Composer
+- **[Escalated pour Rails](https://github.com/escalated-dev/escalated-rails)** — Moteur Ruby on Rails
+- **[Escalated pour Django](https://github.com/escalated-dev/escalated-django)** — Application Django reutilisable
+- **[Escalated pour AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Paquet AdonisJS v6
+- **[Escalated pour Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin de panneau d'administration Filament v3
+- **[Frontend Partage](https://github.com/escalated-dev/escalated)** — Composants UI Vue 3 + Inertia.js (vous etes ici)
+
+## Licence
+
+MIT

--- a/docs/translations/README.it.md
+++ b/docs/translations/README.it.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <b>Italiano</b> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated e un sistema di ticket di supporto integrabile con tracciamento SLA, regole di escalation, workflow per agenti e portale clienti. Questo repository contiene tutte le risorse frontend condivise (Vue 3 + Inertia.js) utilizzate in tutti i framework backend supportati.
+
+👉 **Scopri di piu, guarda le demo e confronta le opzioni Cloud vs Self-Hosted su** **[https://escalated.dev](https://escalated.dev)**
+
+**Non installare questo pacchetto direttamente.** Inizia con il pacchetto backend per il tuo framework — gestisce tutto, incluso l'integrazione di queste risorse frontend.
+
+## Funzionalita
+
+- **Divisione ticket** — Dividi una risposta in un nuovo ticket indipendente preservando il contesto
+- **Posticipo ticket** — Posticipa i ticket con preimpostazioni (1h, 4h, domani, prossima settimana) e riattivazione automatica
+- **Viste salvate / code personalizzate** — Salva, nomina e condividi preimpostazioni di filtri come viste ticket riutilizzabili
+- **Widget di supporto integrabile** — Widget `<script>` pronto all'uso con ricerca KB, modulo ticket e verifica stato
+- **Aggiornamenti in tempo reale** — Supporto WebSocket (Pusher/Reverb/Soketi) con fallback polling automatico
+- **Interruttore knowledge base** — Abilita o disabilita la knowledge base pubblica dalle impostazioni admin
+- **CI: ESLint + Prettier** — Applicazione automatica dello stile del codice ad ogni pull request
+
+## Per Iniziare
+
+Scegli il tuo framework:
+
+| Framework | Repository | Installazione |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [Scarica escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Vedi [configurazione pubspec.yaml](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Ogni repository backend ha istruzioni di configurazione complete — comando di installazione, migrazioni, configurazione e integrazione frontend.
+
+## Tailwind CSS
+
+I componenti Escalated utilizzano classi Tailwind CSS. **Devi** aggiungere questo pacchetto alla configurazione `content` di Tailwind affinche le sue classi non vengano eliminate:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... i tuoi percorsi esistenti
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Senza questo, l'interfaccia Escalated verra renderizzata ma gli stili come gli sfondi dei pulsanti e i colori dei badge saranno assenti.
+
+## Personalizzazione
+
+Escalated viene renderizzato all'interno di un layout autonomo per impostazione predefinita. Per integrarlo nel design system della tua app, usa l'`EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Integrazione Layout
+
+Passa il componente layout della tua app e tutte le pagine Escalated verranno renderizzate al suo interno automaticamente. Il componente layout deve accettare uno slot `#header` e uno slot predefinito:
+
+```vue
+<!-- Il tuo layout deve supportare questi slot -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Quando non viene fornito un layout, Escalated utilizza la propria barra di navigazione integrata.
+
+### Proprieta CSS Personalizzate
+
+L'opzione `theme` imposta proprieta CSS personalizzate che puoi referenziare nei tuoi stili:
+
+| Proprieta | Predefinito | Descrizione |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Colore azione primaria |
+| `--esc-primary-hover` | scurimento automatico | Colore hover primario |
+| `--esc-radius` | `0.5rem` | Raggio bordo per input e pulsanti |
+| `--esc-radius-lg` | scalatura automatica | Raggio bordo per card e pannelli |
+| `--esc-font-family` | ereditato | Override famiglia font |
+
+### Esempi per Framework
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Contenuto di Questo Repository
+
+Tutti i componenti Vue 3 + Inertia.js che alimentano l'interfaccia Escalated. Questi sono identici su Laravel, Rails, Django e AdonisJS — il framework backend li renderizza tramite Inertia.
+
+## 📸 Screenshot
+
+> Gli screenshot vengono generati automaticamente da Storybook tramite il workflow [component-screenshots](.github/workflows/screenshots.yml).
+
+<p align="center">
+  <strong>Pannello Admin (Scuro)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Pannello admin Escalated — modalita scura con navigazione laterale, card KPI, statistiche e lista ticket" width="800" />
+</p>
+
+<p align="center">
+  <strong>Pannello Admin (Chiaro)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Pannello admin Escalated — modalita chiara con navigazione laterale, card KPI, statistiche e lista ticket" width="800" />
+</p>
+
+<p align="center">
+  <strong>Coda Ticket</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Coda ticket Escalated — lista ticket dell'agente con filtri, ricerca, azioni di massa e indicatori SLA" width="800" />
+</p>
+
+<p align="center">
+  <strong>Pannello Agente</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Pannello agente Escalated — navigazione superiore, statistiche e coda ticket assegnati" width="800" />
+</p>
+
+<p align="center">
+  <strong>Vista Dettaglio Ticket</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Vista dettaglio ticket Escalated — thread conversazione, editor risposta e barra laterale ticket con timer SLA" width="800" />
+</p>
+
+### Pagine
+
+**Portale Clienti** — Gestione ticket self-service
+- `pages/Customer/Index.vue` — Lista ticket con filtri stato e ricerca
+- `pages/Customer/Create.vue` — Modulo nuovo ticket con allegati
+- `pages/Customer/Show.vue` — Dettaglio ticket con thread risposte
+
+**Dashboard Agente** — Coda ticket e workflow
+- `pages/Agent/Dashboard.vue` — Panoramica statistiche e ticket recenti
+- `pages/Agent/TicketIndex.vue` — Coda ticket filtrabile
+- `pages/Agent/TicketShow.vue` — Vista ticket completa con barra laterale, note interne, risposte predefinite
+
+**Pannello Admin** — Configurazione sistema
+- `pages/Admin/Reports.vue` — Dashboard analitico
+- `pages/Admin/Departments/` — Gestione dipartimenti (CRUD)
+- `pages/Admin/SlaPolicies/` — Gestione politiche SLA
+- `pages/Admin/EscalationRules/` — Costruttore regole di escalation
+- `pages/Admin/Tags/` — Gestione tag
+- `pages/Admin/CannedResponses/` — Modelli risposte predefinite
+
+### Componenti Condivisi
+
+Blocchi di costruzione riutilizzabili utilizzati nelle pagine sopra.
+
+| Componente | Descrizione |
+|-----------|-------------|
+| `StatusBadge` | Badge colorato per lo stato del ticket |
+| `PriorityBadge` | Badge colorato per la priorita del ticket |
+| `TicketList` | Tabella ticket paginata |
+| `ReplyThread` | Visualizzazione cronologica delle risposte |
+| `ReplyComposer` | Editor risposta/nota con upload file e inserimento risposte predefinite |
+| `ActivityTimeline` | Log di audit degli eventi del ticket |
+| `SlaTimer` | Conto alla rovescia SLA con stati violazione/avviso |
+| `TicketFilters` | Barra filtri stato, priorita, agente, dipartimento |
+| `TicketSidebar` | Barra laterale dettaglio ticket (stato, SLA, tag, attivita) |
+| `AssigneeSelect` | Menu a tendina assegnazione agente |
+| `TagSelect` | Selettore tag a selezione multipla |
+| `FileDropzone` | Upload file drag-and-drop |
+| `AttachmentList` | Visualizzazione allegati con link di download |
+| `StatsCard` | Card metriche con etichetta, valore e tendenza |
+| `EscalatedLayout` | Layout di livello superiore con navigazione (supporta iniezione layout host) |
+| `BulkActionBar` | Barra strumenti per operazioni di massa sui ticket selezionati |
+| `QuickFilters` | Chip filtro a un clic (I Miei Ticket, Non Assegnati, Urgente, SLA Violato) |
+| `MacroDropdown` | Menu a tendina per applicare macro multi-step a un ticket |
+| `FollowButton` | Pulsante toggle per seguire/smettere di seguire un ticket |
+| `SatisfactionRating` | Input valutazione CSAT da 1 a 5 stelle con commento opzionale |
+| `KeyboardShortcutHelp` | Overlay modale che mostra tutte le scorciatoie da tastiera disponibili |
+| `PinnedNotes` | Visualizzazione note interne fissate in cima al thread |
+| `PresenceIndicator` | Indicatore in tempo reale che mostra chi sta visualizzando un ticket |
+
+### Composables
+
+| Composable | Descrizione |
+|------------|-------------|
+| `useKeyboardShortcuts` | Registra e gestisce le scorciatoie da tastiera per le azioni sui ticket |
+
+### Plugin
+
+| Export | Descrizione |
+|--------|-------------|
+| `EscalatedPlugin` | Plugin Vue per iniezione layout e personalizzazione CSS |
+
+## Sviluppo Plugin
+
+Escalated supporta plugin indipendenti dal framework costruiti con il [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). I plugin vengono scritti una volta in TypeScript e funzionano su tutti i backend Escalated.
+
+### Come Funziona il Sistema Plugin Frontend
+
+Il frontend usa `defineEscalatedPlugin()` per registrare componenti Vue — pagine admin personalizzate, widget barra laterale ticket o pannelli dashboard — che vengono montati automaticamente quando il plugin e attivo.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Come si Connette al Backend
+
+Il backend usa `definePlugin()` dal [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) per gestire la logica business TypeScript — sottoscrivere hook del ciclo di vita dei ticket, esporre endpoint API e persistere dati. Le entry frontend e backend lavorano insieme come un singolo pacchetto npm.
+
+```typescript
+// entry backend (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Esempio Rapido: Entrambi i Punti di Ingresso
+
+Un pacchetto plugin pubblicato tipicamente esporta entrambi:
+
+```
+my-plugin/
+  index.ts          ← backend: definePlugin() per logica TypeScript
+  frontend.ts       ← frontend: defineEscalatedPlugin() per componenti Vue
+```
+
+Il framework backend (Laravel, Rails, Django, AdonisJS) carica `index.ts` tramite il [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). L'app Vue importa `frontend.ts` e lo registra con `app.use()`.
+
+### Installazione Plugin
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Risorse
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK TypeScript per costruire plugin
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host runtime per plugin
+- [Guida allo Sviluppo Plugin](https://github.com/escalated-dev/escalated-docs) — Documentazione completa
+
+## Per i Manutentori dei Pacchetti
+
+Se stai costruendo una nuova integrazione backend, questo pacchetto e disponibile su npm:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Importa il plugin
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Importa componenti individuali
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// O referenzia le pagine direttamente per la risoluzione Inertia
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Dipendenze peer: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ecosistema
+
+Questo e il frontend condiviso per il sistema di ticket di supporto Escalated. Pacchetti backend disponibili per ogni framework principale:
+
+- **[Escalated per Laravel](https://github.com/escalated-dev/escalated-laravel)** — Pacchetto Laravel Composer
+- **[Escalated per Rails](https://github.com/escalated-dev/escalated-rails)** — Engine Ruby on Rails
+- **[Escalated per Django](https://github.com/escalated-dev/escalated-django)** — App Django riutilizzabile
+- **[Escalated per AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Pacchetto AdonisJS v6
+- **[Escalated per Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin pannello admin Filament v3
+- **[Frontend Condiviso](https://github.com/escalated-dev/escalated)** — Componenti UI Vue 3 + Inertia.js (sei qui)
+
+## Licenza
+
+MIT

--- a/docs/translations/README.ja.md
+++ b/docs/translations/README.ja.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <b>日本語</b> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalatedは、SLAトラッキング、エスカレーションルール、エージェントワークフロー、カスタマーポータルを備えた組み込み可能なサポートチケットシステムです。このリポジトリには、サポートされているすべてのバックエンドフレームワークで使用される共有フロントエンドアセット（Vue 3 + Inertia.js）が含まれています。
+
+👉 **詳細、デモ、クラウドvsセルフホストオプションの比較は** **[https://escalated.dev](https://escalated.dev)** **をご覧ください**
+
+**このパッケージを直接インストールしないでください。** お使いのフレームワークのバックエンドパッケージから始めてください — フロントエンドアセットの取り込みを含め、すべてを処理します。
+
+## 機能
+
+- **チケット分割** — 返信をコンテキストを保持しながら新しい独立したチケットに分割
+- **チケットスヌーズ** — プリセット（1時間、4時間、明日、来週）でチケットをスヌーズし、自動的にウェイク
+- **保存済みビュー / カスタムキュー** — フィルタープリセットを再利用可能なチケットビューとして保存、命名、共有
+- **組み込み可能なサポートウィジェット** — KB検索、チケットフォーム、ステータスチェック付きのドロップイン`<script>`ウィジェット
+- **リアルタイム更新** — WebSocketサポート（Pusher/Reverb/Soketi）と自動ポーリングフォールバック
+- **ナレッジベーストグル** — 管理設定から公開ナレッジベースを有効/無効に切り替え
+- **CI: ESLint + Prettier** — すべてのプルリクエストでコードスタイルを自動適用
+
+## はじめに
+
+フレームワークを選択してください：
+
+| フレームワーク | リポジトリ | インストール |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [escalated.zipをダウンロード](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | [pubspec.yamlセットアップ](https://github.com/escalated-dev/escalated-flutter#quick-start)を参照 |
+
+各バックエンドリポジトリには、インストールコマンド、マイグレーション、設定、フロントエンド統合を含む完全なセットアップ手順があります。
+
+## Tailwind CSS
+
+EscalatedコンポーネントはTailwind CSSクラスを使用します。クラスがパージされないように、このパッケージをTailwindの`content`設定に追加する**必要があります**：
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... 既存のパス
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+これがないと、Escalated UIはレンダリングされますが、ボタンの背景やバッジの色などのスタイルが欠落します。
+
+## テーマ設定
+
+Escalatedはデフォルトでスタンドアロンレイアウト内にレンダリングされます。アプリのデザインシステムに統合するには、`EscalatedPlugin`を使用してください：
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### レイアウト統合
+
+アプリのレイアウトコンポーネントを渡すと、すべてのEscalatedページが自動的にその中にレンダリングされます。レイアウトコンポーネントは`#header`スロットとデフォルトスロットを受け入れる必要があります：
+
+```vue
+<!-- レイアウトはこれらのスロットをサポートする必要があります -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+レイアウトが提供されない場合、Escalatedは独自の組み込みナビゲーションバーを使用します。
+
+### CSSカスタムプロパティ
+
+`theme`オプションは、独自のスタイルで参照できるCSSカスタムプロパティを設定します：
+
+| プロパティ | デフォルト | 説明 |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | プライマリアクションカラー |
+| `--esc-primary-hover` | 自動的に暗く | プライマリホバーカラー |
+| `--esc-radius` | `0.5rem` | 入力フィールドとボタンのボーダー半径 |
+| `--esc-radius-lg` | 自動スケール | カードとパネルのボーダー半径 |
+| `--esc-font-family` | 継承 | フォントファミリーのオーバーライド |
+
+### フレームワーク別の例
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## このリポジトリの内容
+
+Escalated UIを動かすすべてのVue 3 + Inertia.jsコンポーネント。これらはLaravel、Rails、Django、AdonisJS間で同一です — バックエンドフレームワークがInertia経由でレンダリングします。
+
+## 📸 スクリーンショット
+
+> スクリーンショットは[component-screenshots](.github/workflows/screenshots.yml)ワークフローを通じてStorybookから自動生成されます。
+
+<p align="center">
+  <strong>管理パネル（ダーク）</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Escalated管理パネル — サイドバーナビゲーション、KPIカード、統計、チケットリスト付きダークモード" width="800" />
+</p>
+
+<p align="center">
+  <strong>管理パネル（ライト）</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Escalated管理パネル — サイドバーナビゲーション、KPIカード、統計、チケットリスト付きライトモード" width="800" />
+</p>
+
+<p align="center">
+  <strong>チケットキュー</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Escalatedチケットキュー — フィルター、検索、一括アクション、SLAインジケーター付きエージェントチケットリスト" width="800" />
+</p>
+
+<p align="center">
+  <strong>エージェントパネル</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Escalatedエージェントパネル — トップナビゲーション、統計、割り当てチケットキュー" width="800" />
+</p>
+
+<p align="center">
+  <strong>チケット詳細ビュー</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Escalatedチケット詳細ビュー — 会話スレッド、返信コンポーザー、SLAタイマー付きチケットサイドバー" width="800" />
+</p>
+
+### ページ
+
+**カスタマーポータル** — セルフサービスチケット管理
+- `pages/Customer/Index.vue` — ステータスフィルターと検索付きチケットリスト
+- `pages/Customer/Create.vue` — ファイル添付付き新規チケットフォーム
+- `pages/Customer/Show.vue` — 返信スレッド付きチケット詳細
+
+**エージェントダッシュボード** — チケットキューとワークフロー
+- `pages/Agent/Dashboard.vue` — 統計概要と最近のチケット
+- `pages/Agent/TicketIndex.vue` — フィルタリング可能なチケットキュー
+- `pages/Agent/TicketShow.vue` — サイドバー、内部メモ、定型応答付きフルチケットビュー
+
+**管理パネル** — システム設定
+- `pages/Admin/Reports.vue` — 分析ダッシュボード
+- `pages/Admin/Departments/` — 部門管理（CRUD）
+- `pages/Admin/SlaPolicies/` — SLAポリシー管理
+- `pages/Admin/EscalationRules/` — エスカレーションルールビルダー
+- `pages/Admin/Tags/` — タグ管理
+- `pages/Admin/CannedResponses/` — 定型応答テンプレート
+
+### 共有コンポーネント
+
+上記のページで使用される再利用可能なビルディングブロック。
+
+| コンポーネント | 説明 |
+|-----------|-------------|
+| `StatusBadge` | チケットステータスのカラーバッジ |
+| `PriorityBadge` | チケット優先度のカラーバッジ |
+| `TicketList` | ページネーション付きチケットテーブル |
+| `ReplyThread` | 時系列の返信表示 |
+| `ReplyComposer` | ファイルアップロードと定型応答挿入付き返信/メモエディター |
+| `ActivityTimeline` | チケットイベントの監査ログ |
+| `SlaTimer` | 違反/警告状態付きSLAカウントダウン |
+| `TicketFilters` | ステータス、優先度、エージェント、部門のフィルターバー |
+| `TicketSidebar` | チケット詳細サイドバー（ステータス、SLA、タグ、アクティビティ） |
+| `AssigneeSelect` | エージェント割り当てドロップダウン |
+| `TagSelect` | 複数選択タグピッカー |
+| `FileDropzone` | ドラッグ&ドロップファイルアップロード |
+| `AttachmentList` | ダウンロードリンク付きファイル添付表示 |
+| `StatsCard` | ラベル、値、トレンド付きメトリクスカード |
+| `EscalatedLayout` | ナビゲーション付きトップレベルレイアウト（ホストレイアウトインジェクション対応） |
+| `BulkActionBar` | 選択したチケットの一括操作ツールバー |
+| `QuickFilters` | ワンクリックフィルターチップ（マイチケット、未割り当て、緊急、SLA違反） |
+| `MacroDropdown` | チケットにマルチステップマクロを適用するドロップダウン |
+| `FollowButton` | チケットのフォロー/フォロー解除トグルボタン |
+| `SatisfactionRating` | オプションコメント付き1-5星CSAT評価入力 |
+| `KeyboardShortcutHelp` | 利用可能なすべてのキーボードショートカットを表示するモーダルオーバーレイ |
+| `PinnedNotes` | スレッドの上部に固定された内部メモを表示 |
+| `PresenceIndicator` | チケットを閲覧しているユーザーを表示するリアルタイムインジケーター |
+
+### コンポーザブル
+
+| コンポーザブル | 説明 |
+|------------|-------------|
+| `useKeyboardShortcuts` | チケットアクション用のキーボードショートカットを登録・管理 |
+
+### プラグイン
+
+| エクスポート | 説明 |
+|--------|-------------|
+| `EscalatedPlugin` | レイアウトインジェクションとCSSテーマ設定用のVueプラグイン |
+
+## プラグイン開発
+
+Escalatedは[Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk)で構築されたフレームワーク非依存のプラグインをサポートしています。プラグインはTypeScriptで一度書くだけで、すべてのEscalatedバックエンドで動作します。
+
+### フロントエンドプラグインシステムの仕組み
+
+フロントエンドは`defineEscalatedPlugin()`を使用してVueコンポーネント — カスタム管理ページ、チケットサイドバーウィジェット、ダッシュボードパネル — を登録し、プラグインがアクティブな時に自動的にマウントされます。
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### バックエンドとの接続方法
+
+バックエンドは[Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk)の`definePlugin()`を使用してTypeScriptビジネスロジックを処理します — チケットライフサイクルフックのサブスクライブ、APIエンドポイントの公開、データの永続化。フロントエンドとバックエンドのエントリーは単一のnpmパッケージとして連携します。
+
+```typescript
+// バックエンドエントリー (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### クイック例：両方のエントリーポイント
+
+公開されたプラグインパッケージは通常、両方をエクスポートします：
+
+```
+my-plugin/
+  index.ts          ← バックエンド: TypeScriptロジック用のdefinePlugin()
+  frontend.ts       ← フロントエンド: Vueコンポーネント用のdefineEscalatedPlugin()
+```
+
+バックエンドフレームワーク（Laravel、Rails、Django、AdonisJS）は[Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime)経由で`index.ts`をロードします。VueアプリはAは`frontend.ts`をインポートし、`app.use()`で登録します。
+
+### プラグインのインストール
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### リソース
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — プラグイン構築用TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — プラグイン用ランタイムホスト
+- [プラグイン開発ガイド](https://github.com/escalated-dev/escalated-docs) — 完全なドキュメント
+
+## パッケージメンテナー向け
+
+新しいバックエンド統合を構築している場合、このパッケージはnpmで利用可能です：
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// プラグインのインポート
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// 個別コンポーネントのインポート
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// またはInertia解決用にページを直接参照
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+ピア依存関係: `vue` ^3.3.0、`@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## エコシステム
+
+これはEscalatedサポートチケットシステムの共有フロントエンドです。すべての主要フレームワーク向けのバックエンドパッケージが利用可能です：
+
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composerパッケージ
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Railsエンジン
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django再利用可能アプリ
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6パッケージ
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3管理パネルプラグイン
+- **[共有フロントエンド](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UIコンポーネント（現在のリポジトリ）
+
+## ライセンス
+
+MIT

--- a/docs/translations/README.ko.md
+++ b/docs/translations/README.ko.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <b>한국어</b> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated는 SLA 추적, 에스컬레이션 규칙, 상담원 워크플로우, 고객 포털을 갖춘 임베드 가능한 지원 티켓 시스템입니다. 이 저장소에는 지원되는 모든 백엔드 프레임워크에서 사용되는 공유 프론트엔드 에셋(Vue 3 + Inertia.js)이 포함되어 있습니다.
+
+👉 **자세히 알아보기, 데모 보기, 클라우드 vs 셀프 호스팅 옵션 비교:** **[https://escalated.dev](https://escalated.dev)**
+
+**이 패키지를 직접 설치하지 마세요.** 사용하는 프레임워크의 백엔드 패키지부터 시작하세요 — 프론트엔드 에셋 가져오기를 포함하여 모든 것을 처리합니다.
+
+## 기능
+
+- **티켓 분할** — 컨텍스트를 유지하면서 답변을 새로운 독립 티켓으로 분할
+- **티켓 스누즈** — 프리셋(1시간, 4시간, 내일, 다음 주)으로 티켓을 스누즈하고 자동 웨이크
+- **저장된 뷰 / 사용자 정의 큐** — 필터 프리셋을 재사용 가능한 티켓 뷰로 저장, 이름 지정, 공유
+- **임베드 가능한 지원 위젯** — KB 검색, 티켓 양식, 상태 확인이 포함된 드롭인 `<script>` 위젯
+- **실시간 업데이트** — WebSocket 지원(Pusher/Reverb/Soketi)과 자동 폴링 폴백
+- **지식 베이스 토글** — 관리자 설정에서 공개 지식 베이스 활성화/비활성화
+- **CI: ESLint + Prettier** — 모든 풀 리퀘스트에서 코드 스타일 자동 적용
+
+## 시작하기
+
+프레임워크를 선택하세요:
+
+| 프레임워크 | 저장소 | 설치 |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [escalated.zip 다운로드](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | [pubspec.yaml 설정](https://github.com/escalated-dev/escalated-flutter#quick-start) 참조 |
+
+각 백엔드 저장소에는 설치 명령, 마이그레이션, 설정, 프론트엔드 통합을 포함한 전체 설정 안내가 있습니다.
+
+## Tailwind CSS
+
+Escalated 컴포넌트는 Tailwind CSS 클래스를 사용합니다. 클래스가 퍼지되지 않도록 이 패키지를 Tailwind `content` 설정에 추가**해야 합니다**:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... 기존 경로
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+이것 없이는 Escalated UI가 렌더링되지만 버튼 배경색이나 배지 색상 같은 스타일이 누락됩니다.
+
+## 테마 설정
+
+Escalated는 기본적으로 독립 레이아웃 내에서 렌더링됩니다. 앱의 디자인 시스템에 통합하려면 `EscalatedPlugin`을 사용하세요:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### 레이아웃 통합
+
+앱의 레이아웃 컴포넌트를 전달하면 모든 Escalated 페이지가 자동으로 그 안에서 렌더링됩니다. 레이아웃 컴포넌트는 `#header` 슬롯과 기본 슬롯을 허용해야 합니다:
+
+```vue
+<!-- 레이아웃은 이 슬롯들을 지원해야 합니다 -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+레이아웃이 제공되지 않으면 Escalated는 자체 내장 네비게이션 바를 사용합니다.
+
+### CSS 사용자 정의 속성
+
+`theme` 옵션은 자체 스타일에서 참조할 수 있는 CSS 사용자 정의 속성을 설정합니다:
+
+| 속성 | 기본값 | 설명 |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | 기본 액션 색상 |
+| `--esc-primary-hover` | 자동 어둡게 | 기본 호버 색상 |
+| `--esc-radius` | `0.5rem` | 입력 필드와 버튼의 테두리 반경 |
+| `--esc-radius-lg` | 자동 스케일 | 카드와 패널의 테두리 반경 |
+| `--esc-font-family` | 상속 | 글꼴 패밀리 오버라이드 |
+
+### 프레임워크 예제
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## 이 저장소의 내용
+
+Escalated UI를 구동하는 모든 Vue 3 + Inertia.js 컴포넌트. Laravel, Rails, Django, AdonisJS에서 동일하며 — 백엔드 프레임워크가 Inertia를 통해 렌더링합니다.
+
+## 📸 스크린샷
+
+> 스크린샷은 [component-screenshots](.github/workflows/screenshots.yml) 워크플로우를 통해 Storybook에서 자동 생성됩니다.
+
+<p align="center">
+  <strong>관리자 패널 (다크)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Escalated 관리자 패널 — 사이드바 네비게이션, KPI 카드, 통계, 티켓 목록이 있는 다크 모드" width="800" />
+</p>
+
+<p align="center">
+  <strong>관리자 패널 (라이트)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Escalated 관리자 패널 — 사이드바 네비게이션, KPI 카드, 통계, 티켓 목록이 있는 라이트 모드" width="800" />
+</p>
+
+<p align="center">
+  <strong>티켓 큐</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Escalated 티켓 큐 — 필터, 검색, 일괄 작업, SLA 인디케이터가 있는 상담원 티켓 목록" width="800" />
+</p>
+
+<p align="center">
+  <strong>상담원 패널</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Escalated 상담원 패널 — 상단 네비게이션, 통계, 할당된 티켓 큐" width="800" />
+</p>
+
+<p align="center">
+  <strong>티켓 상세 보기</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Escalated 티켓 상세 보기 — 대화 스레드, 답장 작성기, SLA 타이머가 있는 티켓 사이드바" width="800" />
+</p>
+
+### 페이지
+
+**고객 포털** — 셀프 서비스 티켓 관리
+- `pages/Customer/Index.vue` — 상태 필터와 검색이 있는 티켓 목록
+- `pages/Customer/Create.vue` — 파일 첨부가 가능한 새 티켓 양식
+- `pages/Customer/Show.vue` — 답장 스레드가 있는 티켓 상세
+
+**상담원 대시보드** — 티켓 큐와 워크플로우
+- `pages/Agent/Dashboard.vue` — 통계 개요와 최근 티켓
+- `pages/Agent/TicketIndex.vue` — 필터링 가능한 티켓 큐
+- `pages/Agent/TicketShow.vue` — 사이드바, 내부 메모, 정형 응답이 있는 전체 티켓 보기
+
+**관리자 패널** — 시스템 설정
+- `pages/Admin/Reports.vue` — 분석 대시보드
+- `pages/Admin/Departments/` — 부서 관리 (CRUD)
+- `pages/Admin/SlaPolicies/` — SLA 정책 관리
+- `pages/Admin/EscalationRules/` — 에스컬레이션 규칙 빌더
+- `pages/Admin/Tags/` — 태그 관리
+- `pages/Admin/CannedResponses/` — 정형 응답 템플릿
+
+### 공유 컴포넌트
+
+위 페이지에서 사용되는 재사용 가능한 빌딩 블록.
+
+| 컴포넌트 | 설명 |
+|-----------|-------------|
+| `StatusBadge` | 티켓 상태용 컬러 배지 |
+| `PriorityBadge` | 티켓 우선순위용 컬러 배지 |
+| `TicketList` | 페이지네이션된 티켓 테이블 |
+| `ReplyThread` | 시간순 답장 표시 |
+| `ReplyComposer` | 파일 업로드와 정형 응답 삽입이 가능한 답장/메모 에디터 |
+| `ActivityTimeline` | 티켓 이벤트 감사 로그 |
+| `SlaTimer` | 위반/경고 상태가 있는 SLA 카운트다운 |
+| `TicketFilters` | 상태, 우선순위, 상담원, 부서 필터 바 |
+| `TicketSidebar` | 티켓 상세 사이드바 (상태, SLA, 태그, 활동) |
+| `AssigneeSelect` | 상담원 할당 드롭다운 |
+| `TagSelect` | 다중 선택 태그 피커 |
+| `FileDropzone` | 드래그 앤 드롭 파일 업로드 |
+| `AttachmentList` | 다운로드 링크가 있는 파일 첨부 표시 |
+| `StatsCard` | 라벨, 값, 트렌드가 있는 메트릭 카드 |
+| `EscalatedLayout` | 네비게이션이 있는 최상위 레이아웃 (호스트 레이아웃 인젝션 지원) |
+| `BulkActionBar` | 선택한 티켓에 대한 일괄 작업 툴바 |
+| `QuickFilters` | 원클릭 필터 칩 (내 티켓, 미할당, 긴급, SLA 위반) |
+| `MacroDropdown` | 티켓에 다단계 매크로를 적용하는 드롭다운 |
+| `FollowButton` | 티켓 팔로우/언팔로우 토글 버튼 |
+| `SatisfactionRating` | 선택적 코멘트가 있는 1-5 별 CSAT 평가 입력 |
+| `KeyboardShortcutHelp` | 사용 가능한 모든 키보드 단축키를 표시하는 모달 오버레이 |
+| `PinnedNotes` | 스레드 상단에 고정된 내부 메모 표시 |
+| `PresenceIndicator` | 티켓을 보고 있는 사람을 표시하는 실시간 인디케이터 |
+
+### 컴포저블
+
+| 컴포저블 | 설명 |
+|------------|-------------|
+| `useKeyboardShortcuts` | 티켓 작업용 키보드 단축키 등록 및 관리 |
+
+### 플러그인
+
+| 내보내기 | 설명 |
+|--------|-------------|
+| `EscalatedPlugin` | 레이아웃 인젝션과 CSS 테마 설정용 Vue 플러그인 |
+
+## 플러그인 개발
+
+Escalated는 [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk)로 구축된 프레임워크 비의존적 플러그인을 지원합니다. 플러그인은 TypeScript로 한 번 작성하면 모든 Escalated 백엔드에서 작동합니다.
+
+### 프론트엔드 플러그인 시스템 작동 방식
+
+프론트엔드는 `defineEscalatedPlugin()`을 사용하여 Vue 컴포넌트 — 사용자 정의 관리 페이지, 티켓 사이드바 위젯, 대시보드 패널 — 를 등록하고, 플러그인이 활성화되면 자동으로 마운트됩니다.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### 백엔드와의 연결 방식
+
+백엔드는 [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk)의 `definePlugin()`을 사용하여 TypeScript 비즈니스 로직을 처리합니다 — 티켓 라이프사이클 훅 구독, API 엔드포인트 노출, 데이터 영속화. 프론트엔드와 백엔드 엔트리는 단일 npm 패키지로 함께 작동합니다.
+
+```typescript
+// 백엔드 엔트리 (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### 빠른 예제: 두 진입점
+
+게시된 플러그인 패키지는 일반적으로 둘 다 내보냅니다:
+
+```
+my-plugin/
+  index.ts          ← 백엔드: TypeScript 로직용 definePlugin()
+  frontend.ts       ← 프론트엔드: Vue 컴포넌트용 defineEscalatedPlugin()
+```
+
+백엔드 프레임워크(Laravel, Rails, Django, AdonisJS)는 [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime)을 통해 `index.ts`를 로드합니다. Vue 앱은 `frontend.ts`를 가져와 `app.use()`로 등록합니다.
+
+### 플러그인 설치
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### 리소스
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — 플러그인 구축용 TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — 플러그인용 런타임 호스트
+- [플러그인 개발 가이드](https://github.com/escalated-dev/escalated-docs) — 전체 문서
+
+## 패키지 메인테이너를 위해
+
+새로운 백엔드 통합을 구축하는 경우, 이 패키지는 npm에서 이용 가능합니다:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// 플러그인 가져오기
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// 개별 컴포넌트 가져오기
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// 또는 Inertia 해석을 위해 페이지를 직접 참조
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+피어 의존성: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## 에코시스템
+
+이것은 Escalated 지원 티켓 시스템의 공유 프론트엔드입니다. 모든 주요 프레임워크용 백엔드 패키지가 제공됩니다:
+
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer 패키지
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails 엔진
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django 재사용 가능 앱
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 패키지
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 관리 패널 플러그인
+- **[공유 프론트엔드](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI 컴포넌트 (현재 저장소)
+
+## 라이선스
+
+MIT

--- a/docs/translations/README.nl.md
+++ b/docs/translations/README.nl.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <b>Nederlands</b> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated is een inbedbaar supportticketsysteem met SLA-tracking, escalatieregels, agentworkflows en een klantenportaal. Deze repository bevat alle gedeelde frontend-assets (Vue 3 + Inertia.js) die worden gebruikt in alle ondersteunde backend-frameworks.
+
+👉 **Meer informatie, bekijk demo's en vergelijk Cloud vs Zelf-gehost opties op** **[https://escalated.dev](https://escalated.dev)**
+
+**Installeer dit pakket niet rechtstreeks.** Begin met het backend-pakket voor je framework — dat regelt alles, inclusief het ophalen van deze frontend-assets.
+
+## Functies
+
+- **Ticket splitsen** — Splits een antwoord in een nieuw zelfstandig ticket met behoud van context
+- **Ticket snoozen** — Snooze tickets met voorinstellingen (1u, 4u, morgen, volgende week) en automatisch ontwaken
+- **Opgeslagen weergaven / aangepaste wachtrijen** — Sla filtervoorinstellingen op als herbruikbare ticketweergaven, geef ze een naam en deel ze
+- **Inbedbaar supportwidget** — Drop-in `<script>` widget met KB-zoeken, ticketformulier en statuscontrole
+- **Realtime updates** — WebSocket-ondersteuning (Pusher/Reverb/Soketi) met automatische polling-fallback
+- **Kennisbank schakelaar** — Schakel de openbare kennisbank in of uit vanuit de beheerdersinstellingen
+- **CI: ESLint + Prettier** — Automatische codestijlhandhaving bij elk pull request
+
+## Aan de Slag
+
+Kies je framework:
+
+| Framework | Repository | Installatie |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [Download escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Zie [pubspec.yaml setup](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Elke backend-repository heeft volledige installatie-instructies — installatiecommando, migraties, configuratie en frontend-integratie.
+
+## Tailwind CSS
+
+Escalated-componenten gebruiken Tailwind CSS-klassen. Je **moet** dit pakket toevoegen aan je Tailwind `content`-configuratie zodat de klassen niet worden verwijderd:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... je bestaande paden
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Zonder dit wordt de Escalated UI weergegeven, maar stijlen zoals knopachtergronden en badgekleuren ontbreken.
+
+## Thema's
+
+Escalated wordt standaard weergegeven in een zelfstandige layout. Om het te integreren in het ontwerpsysteem van je app, gebruik je het `EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Layout-integratie
+
+Geef het layout-component van je app door en alle Escalated-pagina's worden automatisch daarin weergegeven. Het layout-component moet een `#header` slot en een standaard slot accepteren:
+
+```vue
+<!-- Je layout moet deze slots ondersteunen -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Wanneer geen layout wordt opgegeven, gebruikt Escalated zijn eigen ingebouwde navigatiebalk.
+
+### Aangepaste CSS-eigenschappen
+
+De `theme` optie stelt aangepaste CSS-eigenschappen in die je kunt refereren in je eigen stijlen:
+
+| Eigenschap | Standaard | Beschrijving |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Primaire actiekleur |
+| `--esc-primary-hover` | automatisch donkerder | Primaire hover-kleur |
+| `--esc-radius` | `0.5rem` | Randradius voor invoervelden en knoppen |
+| `--esc-radius-lg` | automatisch geschaald | Randradius voor kaarten en panelen |
+| `--esc-font-family` | overgenomen | Lettertypefamilie-overschrijving |
+
+### Framework-voorbeelden
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Wat Zit er in Deze Repository
+
+Alle Vue 3 + Inertia.js componenten die de Escalated UI aandrijven. Deze zijn identiek voor Laravel, Rails, Django en AdonisJS — het backend-framework rendert ze via Inertia.
+
+## 📸 Screenshots
+
+> Screenshots worden automatisch gegenereerd vanuit Storybook via de [component-screenshots](.github/workflows/screenshots.yml) workflow.
+
+<p align="center">
+  <strong>Beheerderspaneel (Donker)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Escalated Beheerderspaneel — donkere modus met zijbalknavigatie, KPI-kaarten, statistieken en ticketlijst" width="800" />
+</p>
+
+<p align="center">
+  <strong>Beheerderspaneel (Licht)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Escalated Beheerderspaneel — lichte modus met zijbalknavigatie, KPI-kaarten, statistieken en ticketlijst" width="800" />
+</p>
+
+<p align="center">
+  <strong>Ticketwachtrij</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Escalated Ticketwachtrij — agent ticketlijst met filters, zoeken, bulkacties en SLA-indicatoren" width="800" />
+</p>
+
+<p align="center">
+  <strong>Agentpaneel</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Escalated Agentpaneel — bovenste navigatie, statistieken en toegewezen ticketwachtrij" width="800" />
+</p>
+
+<p align="center">
+  <strong>Ticket Detailweergave</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Escalated Ticket Detailweergave — gespreksthread, antwoordcomposer en ticketzijbalk met SLA-timer" width="800" />
+</p>
+
+### Pagina's
+
+**Klantenportaal** — Selfservice ticketbeheer
+- `pages/Customer/Index.vue` — Ticketlijst met statusfilters en zoeken
+- `pages/Customer/Create.vue` — Nieuw ticketformulier met bestandsbijlagen
+- `pages/Customer/Show.vue` — Ticketdetail met antwoordthread
+
+**Agent Dashboard** — Ticketwachtrij en workflows
+- `pages/Agent/Dashboard.vue` — Statistiekenoverzicht en recente tickets
+- `pages/Agent/TicketIndex.vue` — Filterbare ticketwachtrij
+- `pages/Agent/TicketShow.vue` — Volledige ticketweergave met zijbalk, interne notities, standaardantwoorden
+
+**Beheerderspaneel** — Systeemconfiguratie
+- `pages/Admin/Reports.vue` — Analysedashboard
+- `pages/Admin/Departments/` — Afdelingsbeheer (CRUD)
+- `pages/Admin/SlaPolicies/` — SLA-beleidsbeheer
+- `pages/Admin/EscalationRules/` — Escalatieregel-builder
+- `pages/Admin/Tags/` — Tagbeheer
+- `pages/Admin/CannedResponses/` — Standaardantwoordsjablonen
+
+### Gedeelde Componenten
+
+Herbruikbare bouwstenen die worden gebruikt op bovenstaande pagina's.
+
+| Component | Beschrijving |
+|-----------|-------------|
+| `StatusBadge` | Gekleurde badge voor ticketstatus |
+| `PriorityBadge` | Gekleurde badge voor ticketprioriteit |
+| `TicketList` | Gepagineerde tickettabel |
+| `ReplyThread` | Chronologische antwoordweergave |
+| `ReplyComposer` | Antwoord-/notitie-editor met bestandsupload en standaardantwoord-invoeging |
+| `ActivityTimeline` | Auditlog van ticketgebeurtenissen |
+| `SlaTimer` | SLA-aftelling met overtredings-/waarschuwingsstatussen |
+| `TicketFilters` | Filter balk voor status, prioriteit, agent, afdeling |
+| `TicketSidebar` | Ticketdetail-zijbalk (status, SLA, tags, activiteit) |
+| `AssigneeSelect` | Dropdown voor agenttoewijzing |
+| `TagSelect` | Multi-select tagkiezer |
+| `FileDropzone` | Drag-and-drop bestandsupload |
+| `AttachmentList` | Bestandsbijlageweergave met downloadlinks |
+| `StatsCard` | Metriekskaart met label, waarde en trend |
+| `EscalatedLayout` | Top-level layout met navigatie (ondersteunt host layout-injectie) |
+| `BulkActionBar` | Werkbalk voor bulkoperaties op geselecteerde tickets |
+| `QuickFilters` | Eenklik-filterchips (Mijn Tickets, Niet-toegewezen, Urgent, SLA-overtreding) |
+| `MacroDropdown` | Dropdown om meerstaps-macro's op een ticket toe te passen |
+| `FollowButton` | Schakelknop om een ticket te volgen/ontvolgen |
+| `SatisfactionRating` | 1-5 sterren CSAT-beoordelingsinvoer met optioneel commentaar |
+| `KeyboardShortcutHelp` | Modale overlay met alle beschikbare sneltoetsen |
+| `PinnedNotes` | Weergave van vastgepinde interne notities bovenaan de thread |
+| `PresenceIndicator` | Realtime indicator die toont wie een ticket bekijkt |
+
+### Composables
+
+| Composable | Beschrijving |
+|------------|-------------|
+| `useKeyboardShortcuts` | Registreert en beheert sneltoetsen voor ticketacties |
+
+### Plugin
+
+| Export | Beschrijving |
+|--------|-------------|
+| `EscalatedPlugin` | Vue-plugin voor layout-injectie en CSS-thema's |
+
+## Plugin-ontwikkeling
+
+Escalated ondersteunt framework-onafhankelijke plugins gebouwd met de [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Plugins worden eenmalig geschreven in TypeScript en werken op alle Escalated-backends.
+
+### Hoe het Frontend Plugin Systeem Werkt
+
+De frontend gebruikt `defineEscalatedPlugin()` om Vue-componenten te registreren — aangepaste beheerderspagina's, ticketzijbalk-widgets of dashboardpanelen — die automatisch worden gemount wanneer de plugin actief is.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Hoe het Verbindt met de Backend
+
+De backend gebruikt `definePlugin()` van de [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) om TypeScript-bedrijfslogica af te handelen — abonneren op ticket lifecycle hooks, API-endpoints blootleggen en gegevens persisteren. De frontend- en backend-ingangen werken samen als een enkel npm-pakket.
+
+```typescript
+// backend-ingang (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Snel Voorbeeld: Beide Ingangspunten
+
+Een gepubliceerd plugin-pakket exporteert doorgaans beide:
+
+```
+my-plugin/
+  index.ts          ← backend: definePlugin() voor TypeScript-logica
+  frontend.ts       ← frontend: defineEscalatedPlugin() voor Vue-componenten
+```
+
+Het backend-framework (Laravel, Rails, Django, AdonisJS) laadt `index.ts` via de [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). De Vue-app importeert `frontend.ts` en registreert het met `app.use()`.
+
+### Plugins Installeren
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Bronnen
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK voor het bouwen van plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Runtime host voor plugins
+- [Plugin Ontwikkelgids](https://github.com/escalated-dev/escalated-docs) — Volledige documentatie
+
+## Voor Pakketbeheerders
+
+Als je een nieuwe backend-integratie bouwt, is dit pakket beschikbaar op npm:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Importeer de plugin
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Importeer individuele componenten
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// Of verwijs direct naar pagina's voor Inertia-resolutie
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Peer-afhankelijkheden: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ecosysteem
+
+Dit is de gedeelde frontend voor het Escalated supportticketsysteem. Backend-pakketten beschikbaar voor elk groot framework:
+
+- **[Escalated voor Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer-pakket
+- **[Escalated voor Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails engine
+- **[Escalated voor Django](https://github.com/escalated-dev/escalated-django)** — Herbruikbare Django-app
+- **[Escalated voor AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6-pakket
+- **[Escalated voor Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 beheerderspaneel-plugin
+- **[Gedeelde Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI-componenten (je bent hier)
+
+## Licentie
+
+MIT

--- a/docs/translations/README.pl.md
+++ b/docs/translations/README.pl.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <b>Polski</b> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated to osadzalny system zgloszen wsparcia z monitorowaniem SLA, regulami eskalacji, przepywami pracy agentow i portalem klienta. To repozytorium zawiera wszystkie wspoldzielone zasoby frontendowe (Vue 3 + Inertia.js) uzywane we wszystkich obslugiwanych frameworkach backendowych.
+
+👉 **Dowiedz sie wiecej, obejrzyj dema i porownaj opcje Chmura vs Samodzielny hosting na** **[https://escalated.dev](https://escalated.dev)**
+
+**Nie instaluj tego pakietu bezposrednio.** Zacznij od pakietu backendowego dla swojego frameworka — zajmie sie wszystkim, w tym pobieraniem tych zasobow frontendowych.
+
+## Funkcje
+
+- **Dzielenie zgloszen** — Podziel odpowiedz na nowe samodzielne zgloszenie z zachowaniem kontekstu
+- **Odkadanie zgloszen** — Odloz zgloszenia z predefiniowanymi ustawieniami (1h, 4h, jutro, nastepny tydzien) i automatycznym budzeniem
+- **Zapisane widoki / niestandardowe kolejki** — Zapisuj, nazywaj i udostepniaj ustawienia filtrow jako wielokrotnie uzywane widoki zgloszen
+- **Osadzalny widget wsparcia** — Gotowy widget `<script>` z wyszukiwaniem bazy wiedzy, formularzem zgloszenia i sprawdzaniem statusu
+- **Aktualizacje w czasie rzeczywistym** — Obsluga WebSocket (Pusher/Reverb/Soketi) z automatycznym fallbackiem pollingu
+- **Przelacznik bazy wiedzy** — Wlacz lub wylacz publiczna baze wiedzy w ustawieniach administratora
+- **CI: ESLint + Prettier** — Automatyczne egzekwowanie stylu kodu przy kazdym pull requeście
+
+## Pierwsze Kroki
+
+Wybierz swoj framework:
+
+| Framework | Repozytorium | Instalacja |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [Pobierz escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Zobacz [konfiguracja pubspec.yaml](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Kazde repozytorium backendowe ma pelne instrukcje konfiguracji — polecenie instalacji, migracje, konfiguracja i integracja frontendowa.
+
+## Tailwind CSS
+
+Komponenty Escalated uzywaja klas Tailwind CSS. **Musisz** dodac ten pakiet do konfiguracji `content` Tailwinda, aby jego klasy nie zostaly usuniete:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... twoje istniejace sciezki
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Bez tego interfejs Escalated zostanie wyrenderowany, ale style takie jak tla przyciskow i kolory odznak beda brakujace.
+
+## Motywy
+
+Escalated domyslnie renderuje sie wewnatrz samodzielnego layoutu. Aby zintegrowac go z systemem projektowania swojej aplikacji, uzyj `EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Integracja Layoutu
+
+Przekaz komponent layoutu swojej aplikacji, a wszystkie strony Escalated beda renderowane wewnatrz niego automatycznie. Komponent layoutu musi akceptowac slot `#header` i domyslny slot:
+
+```vue
+<!-- Twoj layout musi obslugiwac te sloty -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Gdy nie zostanie podany layout, Escalated uzywa wlasnego wbudowanego paska nawigacji.
+
+### Niestandardowe Wlasciwosci CSS
+
+Opcja `theme` ustawia niestandardowe wlasciwosci CSS, do ktorych mozesz sie odwolywac we wlasnych stylach:
+
+| Wlasciwosc | Domyslnie | Opis |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Glowny kolor akcji |
+| `--esc-primary-hover` | automatycznie przyciemniony | Glowny kolor najechania |
+| `--esc-radius` | `0.5rem` | Promien obramowania dla pol i przyciskow |
+| `--esc-radius-lg` | automatycznie skalowany | Promien obramowania dla kart i paneli |
+| `--esc-font-family` | dziedziczony | Nadpisanie rodziny czcionek |
+
+### Przyklady Frameworkow
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Co Jest w Tym Repozytorium
+
+Wszystkie komponenty Vue 3 + Inertia.js napedzajace interfejs Escalated. Sa identyczne w Laravel, Rails, Django i AdonisJS — framework backendowy renderuje je przez Inertia.
+
+## 📸 Zrzuty Ekranu
+
+> Zrzuty ekranu sa automatycznie generowane ze Storybooka przez workflow [component-screenshots](.github/workflows/screenshots.yml).
+
+<p align="center">
+  <strong>Panel Administratora (Ciemny)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Panel administratora Escalated — tryb ciemny z nawigacja boczna, kartami KPI, statystykami i lista zgloszen" width="800" />
+</p>
+
+<p align="center">
+  <strong>Panel Administratora (Jasny)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Panel administratora Escalated — tryb jasny z nawigacja boczna, kartami KPI, statystykami i lista zgloszen" width="800" />
+</p>
+
+<p align="center">
+  <strong>Kolejka Zgloszen</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Kolejka zgloszen Escalated — lista zgloszen agenta z filtrami, wyszukiwaniem, akcjami masowymi i wskaznikami SLA" width="800" />
+</p>
+
+<p align="center">
+  <strong>Panel Agenta</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Panel agenta Escalated — gorny pasek nawigacji, statystyki i kolejka przypisanych zgloszen" width="800" />
+</p>
+
+<p align="center">
+  <strong>Widok Szczegolowy Zgloszenia</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Widok szczegolowy zgloszenia Escalated — watek rozmowy, edytor odpowiedzi i boczny panel zgloszenia z zegarem SLA" width="800" />
+</p>
+
+### Strony
+
+**Portal Klienta** — Samoobslugowe zarzadzanie zgloszeniami
+- `pages/Customer/Index.vue` — Lista zgloszen z filtrami statusu i wyszukiwaniem
+- `pages/Customer/Create.vue` — Formularz nowego zgloszenia z zalacznikami plikow
+- `pages/Customer/Show.vue` — Szczegoly zgloszenia z watkiem odpowiedzi
+
+**Panel Agenta** — Kolejka zgloszen i przeplywy pracy
+- `pages/Agent/Dashboard.vue` — Przeglad statystyk i ostatnich zgloszen
+- `pages/Agent/TicketIndex.vue` — Filtrowalna kolejka zgloszen
+- `pages/Agent/TicketShow.vue` — Pelny widok zgloszenia z panelem bocznym, notatkami wewnetnymi, gotowymi odpowiedziami
+
+**Panel Administratora** — Konfiguracja systemu
+- `pages/Admin/Reports.vue` — Panel analityczny
+- `pages/Admin/Departments/` — Zarzadzanie dzialami (CRUD)
+- `pages/Admin/SlaPolicies/` — Zarzadzanie politykami SLA
+- `pages/Admin/EscalationRules/` — Kreator regul eskalacji
+- `pages/Admin/Tags/` — Zarzadzanie tagami
+- `pages/Admin/CannedResponses/` — Szablony gotowych odpowiedzi
+
+### Wspoldzielone Komponenty
+
+Wielokrotnie uzywane bloki budulcowe stosowane na powyzszych stronach.
+
+| Komponent | Opis |
+|-----------|-------------|
+| `StatusBadge` | Kolorowa odznaka statusu zgloszenia |
+| `PriorityBadge` | Kolorowa odznaka priorytetu zgloszenia |
+| `TicketList` | Paginowana tabela zgloszen |
+| `ReplyThread` | Chronologiczny widok odpowiedzi |
+| `ReplyComposer` | Edytor odpowiedzi/notatki z przesylaniem plikow i wstawianiem gotowych odpowiedzi |
+| `ActivityTimeline` | Dziennik audytu zdarzen zgloszenia |
+| `SlaTimer` | Odliczanie SLA ze stanami naruszenia/ostrzezenia |
+| `TicketFilters` | Pasek filtrow statusu, priorytetu, agenta, dzialu |
+| `TicketSidebar` | Boczny panel szczegulow zgloszenia (status, SLA, tagi, aktywnosc) |
+| `AssigneeSelect` | Rozwijana lista przypisania agenta |
+| `TagSelect` | Wielokrotny wybor tagow |
+| `FileDropzone` | Przesylanie plikow przeciagnij i upusc |
+| `AttachmentList` | Wyswietlanie zalacznikow z linkami do pobrania |
+| `StatsCard` | Karta metryk z etykieta, wartoscia i trendem |
+| `EscalatedLayout` | Layout najwyzszego poziomu z nawigacja (obsluguje wstrzykiwanie layoutu hosta) |
+| `BulkActionBar` | Pasek narzedzi do operacji masowych na wybranych zgloszeniach |
+| `QuickFilters` | Chipy filtrow jednym kliknieciem (Moje Zgloszenia, Nieprzypisane, Pilne, SLA Naruszone) |
+| `MacroDropdown` | Rozwijana lista do stosowania wieloetapowych makr na zgloszeniu |
+| `FollowButton` | Przycisk przelaczania sledzenia/odsledzenia zgloszenia |
+| `SatisfactionRating` | Wprowadzanie oceny CSAT 1-5 gwiazdek z opcjonalnym komentarzem |
+| `KeyboardShortcutHelp` | Nakladka modalna pokazujaca wszystkie dostepne skroty klawiszowe |
+| `PinnedNotes` | Wyswietlanie przypinych notatek wewnetrznych na gorze watku |
+| `PresenceIndicator` | Wskaznik w czasie rzeczywistym pokazujacy kto przegada zgloszenie |
+
+### Composables
+
+| Composable | Opis |
+|------------|-------------|
+| `useKeyboardShortcuts` | Rejestruje i zarzadza skrotami klawiszowymi dla akcji na zgloszeniach |
+
+### Plugin
+
+| Eksport | Opis |
+|--------|-------------|
+| `EscalatedPlugin` | Plugin Vue do wstrzykiwania layoutu i motywow CSS |
+
+## Tworzenie Pluginow
+
+Escalated obsluguje pluginy niezalezne od frameworka, zbudowane za pomoca [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Pluginy sa pisane raz w TypeScript i dzialaja na wszystkich backendach Escalated.
+
+### Jak Dziala System Pluginow Frontendowych
+
+Frontend uzywa `defineEscalatedPlugin()` do rejestrowania komponentow Vue — niestandardowych stron administratora, widgetow paska bocznego zgloszen lub paneli dashboardu — ktore sa automatycznie montowane, gdy plugin jest aktywny.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Jak Laczy Sie z Backendem
+
+Backend uzywa `definePlugin()` z [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) do obslugi logiki biznesowej TypeScript — subskrybowania hookow cyklu zycia zgloszen, udostepniania endpointow API i utrwalania danych. Wpisy frontendowe i backendowe dzialaja razem jako pojedynczy pakiet npm.
+
+```typescript
+// wpis backendowy (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Szybki Przyklad: Oba Punkty Wejscia
+
+Opublikowany pakiet pluginu typowo eksportuje oba:
+
+```
+my-plugin/
+  index.ts          ← backend: definePlugin() dla logiki TypeScript
+  frontend.ts       ← frontend: defineEscalatedPlugin() dla komponentow Vue
+```
+
+Framework backendowy (Laravel, Rails, Django, AdonisJS) laduje `index.ts` przez [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). Aplikacja Vue importuje `frontend.ts` i rejestruje go za pomoca `app.use()`.
+
+### Instalacja Pluginow
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Zasoby
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK do tworzenia pluginow
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host uruchomieniowy dla pluginow
+- [Przewodnik Tworzenia Pluginow](https://github.com/escalated-dev/escalated-docs) — Pelna dokumentacja
+
+## Dla Opiekunow Pakietow
+
+Jesli budujesz nowa integracje backendowa, ten pakiet jest dostepny na npm:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Importuj plugin
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Importuj pojedyncze komponenty
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// Lub odwoluj sie do stron bezposrednio dla rozdzielczosci Inertia
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Zaleznosci peer: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ekosystem
+
+To jest wspoldzielony frontend dla systemu zgloszen wsparcia Escalated. Pakiety backendowe dostepne dla kazdego waznego frameworka:
+
+- **[Escalated dla Laravel](https://github.com/escalated-dev/escalated-laravel)** — Pakiet Laravel Composer
+- **[Escalated dla Rails](https://github.com/escalated-dev/escalated-rails)** — Silnik Ruby on Rails
+- **[Escalated dla Django](https://github.com/escalated-dev/escalated-django)** — Wielokrotnie uzywana aplikacja Django
+- **[Escalated dla AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Pakiet AdonisJS v6
+- **[Escalated dla Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin panelu administratora Filament v3
+- **[Wspoldzielony Frontend](https://github.com/escalated-dev/escalated)** — Komponenty UI Vue 3 + Inertia.js (jestes tutaj)
+
+## Licencja
+
+MIT

--- a/docs/translations/README.pt-BR.md
+++ b/docs/translations/README.pt-BR.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <b>Português (BR)</b> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated e um sistema de tickets de suporte incorporavel com rastreamento de SLA, regras de escalonamento, fluxos de trabalho de agentes e portal do cliente. Este repositorio contem todos os assets de frontend compartilhados (Vue 3 + Inertia.js) usados em todos os frameworks de backend suportados.
+
+👉 **Saiba mais, veja demos e compare as opcoes Cloud vs Auto-hospedado em** **[https://escalated.dev](https://escalated.dev)**
+
+**Nao instale este pacote diretamente.** Comece com o pacote de backend para seu framework — ele cuida de tudo, incluindo a incorporacao destes assets de frontend.
+
+## Recursos
+
+- **Divisao de tickets** — Divida uma resposta em um novo ticket independente preservando o contexto
+- **Adiamento de tickets** — Adie tickets com predefinicoes (1h, 4h, amanha, proxima semana) e despertar automatico
+- **Visualizacoes salvas / filas personalizadas** — Salve, nomeie e compartilhe predefinicoes de filtros como visualizacoes de tickets reutilizaveis
+- **Widget de suporte incorporavel** — Widget `<script>` pronto para uso com busca na KB, formulario de ticket e verificacao de status
+- **Atualizacoes em tempo real** — Suporte a WebSocket (Pusher/Reverb/Soketi) com fallback de polling automatico
+- **Alternancia da base de conhecimento** — Ative ou desative a base de conhecimento publica nas configuracoes de administrador
+- **CI: ESLint + Prettier** — Aplicacao automatica de estilo de codigo em cada pull request
+
+## Comecando
+
+Escolha seu framework:
+
+| Framework | Repositorio | Instalacao |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [Baixar escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Veja [configuracao do pubspec.yaml](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Cada repositorio de backend tem instrucoes completas de configuracao — comando de instalacao, migracoes, configuracao e integracao de frontend.
+
+## Tailwind CSS
+
+Os componentes do Escalated usam classes Tailwind CSS. Voce **deve** adicionar este pacote a configuracao `content` do Tailwind para que suas classes nao sejam purgadas:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... seus caminhos existentes
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Sem isso, a interface do Escalated sera renderizada, mas estilos como fundos de botoes e cores de badges estarao ausentes.
+
+## Temas
+
+O Escalated renderiza dentro de um layout autonomo por padrao. Para integra-lo ao sistema de design do seu aplicativo, use o `EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Integracao de Layout
+
+Passe o componente de layout do seu aplicativo e todas as paginas do Escalated serao renderizadas dentro dele automaticamente. O componente de layout deve aceitar um slot `#header` e um slot padrao:
+
+```vue
+<!-- Seu layout deve suportar estes slots -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Quando nenhum layout e fornecido, o Escalated usa sua propria barra de navegacao embutida.
+
+### Propriedades CSS Personalizadas
+
+A opcao `theme` define propriedades CSS personalizadas que voce pode referenciar em seus proprios estilos:
+
+| Propriedade | Padrao | Descricao |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Cor de acao primaria |
+| `--esc-primary-hover` | escurecimento automatico | Cor de hover primaria |
+| `--esc-radius` | `0.5rem` | Raio de borda para campos e botoes |
+| `--esc-radius-lg` | escala automatica | Raio de borda para cards e paineis |
+| `--esc-font-family` | herdado | Substituicao da familia de fontes |
+
+### Exemplos por Framework
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## O Que Ha Neste Repositorio
+
+Todos os componentes Vue 3 + Inertia.js que alimentam a interface do Escalated. Eles sao identicos no Laravel, Rails, Django e AdonisJS — o framework de backend os renderiza via Inertia.
+
+## 📸 Capturas de Tela
+
+> As capturas de tela sao geradas automaticamente do Storybook pelo workflow [component-screenshots](.github/workflows/screenshots.yml).
+
+<p align="center">
+  <strong>Painel de Administracao (Escuro)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Painel de administracao do Escalated — modo escuro com navegacao lateral, cards KPI, estatisticas e lista de tickets" width="800" />
+</p>
+
+<p align="center">
+  <strong>Painel de Administracao (Claro)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Painel de administracao do Escalated — modo claro com navegacao lateral, cards KPI, estatisticas e lista de tickets" width="800" />
+</p>
+
+<p align="center">
+  <strong>Fila de Tickets</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Fila de tickets do Escalated — lista de tickets do agente com filtros, busca, acoes em massa e indicadores SLA" width="800" />
+</p>
+
+<p align="center">
+  <strong>Painel do Agente</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Painel do agente do Escalated — navegacao superior, estatisticas e fila de tickets atribuidos" width="800" />
+</p>
+
+<p align="center">
+  <strong>Visualizacao Detalhada do Ticket</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Visualizacao detalhada do ticket do Escalated — thread de conversa, editor de resposta e barra lateral do ticket com temporizador SLA" width="800" />
+</p>
+
+### Paginas
+
+**Portal do Cliente** — Gerenciamento de tickets por autoatendimento
+- `pages/Customer/Index.vue` — Lista de tickets com filtros de status e busca
+- `pages/Customer/Create.vue` — Formulario de novo ticket com anexos de arquivos
+- `pages/Customer/Show.vue` — Detalhe do ticket com thread de respostas
+
+**Dashboard do Agente** — Fila de tickets e fluxos de trabalho
+- `pages/Agent/Dashboard.vue` — Visao geral de estatisticas e tickets recentes
+- `pages/Agent/TicketIndex.vue` — Fila de tickets filtravel
+- `pages/Agent/TicketShow.vue` — Visualizacao completa do ticket com barra lateral, notas internas, respostas prontas
+
+**Painel de Administracao** — Configuracao do sistema
+- `pages/Admin/Reports.vue` — Dashboard analitico
+- `pages/Admin/Departments/` — Gerenciamento de departamentos (CRUD)
+- `pages/Admin/SlaPolicies/` — Gerenciamento de politicas SLA
+- `pages/Admin/EscalationRules/` — Construtor de regras de escalonamento
+- `pages/Admin/Tags/` — Gerenciamento de tags
+- `pages/Admin/CannedResponses/` — Modelos de respostas prontas
+
+### Componentes Compartilhados
+
+Blocos de construcao reutilizaveis usados nas paginas acima.
+
+| Componente | Descricao |
+|-----------|-------------|
+| `StatusBadge` | Badge colorido para status do ticket |
+| `PriorityBadge` | Badge colorido para prioridade do ticket |
+| `TicketList` | Tabela de tickets paginada |
+| `ReplyThread` | Exibicao cronologica de respostas |
+| `ReplyComposer` | Editor de resposta/nota com upload de arquivos e insercao de respostas prontas |
+| `ActivityTimeline` | Log de auditoria de eventos do ticket |
+| `SlaTimer` | Contagem regressiva SLA com estados de violacao/aviso |
+| `TicketFilters` | Barra de filtros de status, prioridade, agente, departamento |
+| `TicketSidebar` | Barra lateral de detalhe do ticket (status, SLA, tags, atividade) |
+| `AssigneeSelect` | Dropdown de atribuicao de agente |
+| `TagSelect` | Seletor de tags com selecao multipla |
+| `FileDropzone` | Upload de arquivos arrastar e soltar |
+| `AttachmentList` | Exibicao de anexos de arquivos com links de download |
+| `StatsCard` | Card de metricas com rotulo, valor e tendencia |
+| `EscalatedLayout` | Layout de nivel superior com navegacao (suporta injecao de layout do host) |
+| `BulkActionBar` | Barra de ferramentas para operacoes em massa em tickets selecionados |
+| `QuickFilters` | Chips de filtro com um clique (Meus Tickets, Nao Atribuidos, Urgente, SLA Violado) |
+| `MacroDropdown` | Dropdown para aplicar macros de multiplas etapas em um ticket |
+| `FollowButton` | Botao de alternancia para seguir/deixar de seguir um ticket |
+| `SatisfactionRating` | Entrada de avaliacao CSAT de 1-5 estrelas com comentario opcional |
+| `KeyboardShortcutHelp` | Sobreposicao modal mostrando todos os atalhos de teclado disponiveis |
+| `PinnedNotes` | Exibicao de notas internas fixadas no topo do thread |
+| `PresenceIndicator` | Indicador em tempo real mostrando quem esta visualizando um ticket |
+
+### Composables
+
+| Composable | Descricao |
+|------------|-------------|
+| `useKeyboardShortcuts` | Registra e gerencia atalhos de teclado para acoes em tickets |
+
+### Plugin
+
+| Exportacao | Descricao |
+|--------|-------------|
+| `EscalatedPlugin` | Plugin Vue para injecao de layout e temas CSS |
+
+## Desenvolvimento de Plugins
+
+O Escalated suporta plugins independentes de framework construidos com o [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Os plugins sao escritos uma vez em TypeScript e funcionam em todos os backends do Escalated.
+
+### Como Funciona o Sistema de Plugins do Frontend
+
+O frontend usa `defineEscalatedPlugin()` para registrar componentes Vue — paginas de administracao personalizadas, widgets da barra lateral de tickets ou paineis de dashboard — que sao montados automaticamente quando o plugin esta ativo.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Como se Conecta ao Backend
+
+O backend usa `definePlugin()` do [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) para lidar com logica de negocios TypeScript — assinar hooks do ciclo de vida de tickets, expor endpoints de API e persistir dados. As entradas de frontend e backend trabalham juntas como um unico pacote npm.
+
+```typescript
+// entrada do backend (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Exemplo Rapido: Ambos Pontos de Entrada
+
+Um pacote de plugin publicado normalmente exporta ambos:
+
+```
+my-plugin/
+  index.ts          ← backend: definePlugin() para logica TypeScript
+  frontend.ts       ← frontend: defineEscalatedPlugin() para componentes Vue
+```
+
+O framework de backend (Laravel, Rails, Django, AdonisJS) carrega `index.ts` via [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). O app Vue importa `frontend.ts` e o registra com `app.use()`.
+
+### Instalando Plugins
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Recursos
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — SDK TypeScript para construir plugins
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Host de runtime para plugins
+- [Guia de Desenvolvimento de Plugins](https://github.com/escalated-dev/escalated-docs) — Documentacao completa
+
+## Para Mantenedores de Pacotes
+
+Se voce esta construindo uma nova integracao de backend, este pacote esta disponivel no npm:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Importar o plugin
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Importar componentes individuais
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// Ou referenciar paginas diretamente para resolucao do Inertia
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Dependencias peer: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ecossistema
+
+Este e o frontend compartilhado para o sistema de tickets de suporte Escalated. Pacotes de backend disponiveis para cada framework principal:
+
+- **[Escalated para Laravel](https://github.com/escalated-dev/escalated-laravel)** — Pacote Laravel Composer
+- **[Escalated para Rails](https://github.com/escalated-dev/escalated-rails)** — Engine Ruby on Rails
+- **[Escalated para Django](https://github.com/escalated-dev/escalated-django)** — App Django reutilizavel
+- **[Escalated para AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Pacote AdonisJS v6
+- **[Escalated para Filament](https://github.com/escalated-dev/escalated-filament)** — Plugin do painel de administracao Filament v3
+- **[Frontend Compartilhado](https://github.com/escalated-dev/escalated)** — Componentes UI Vue 3 + Inertia.js (voce esta aqui)
+
+## Licenca
+
+MIT

--- a/docs/translations/README.ru.md
+++ b/docs/translations/README.ru.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <b>Русский</b> •
+  <a href="README.tr.md">Türkçe</a> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated — это встраиваемая система тикетов поддержки с отслеживанием SLA, правилами эскалации, рабочими процессами агентов и клиентским порталом. Этот репозиторий содержит все общие фронтенд-ресурсы (Vue 3 + Inertia.js), используемые во всех поддерживаемых бэкенд-фреймворках.
+
+👉 **Узнайте больше, посмотрите демо и сравните варианты Облако vs Самостоятельный хостинг на** **[https://escalated.dev](https://escalated.dev)**
+
+**Не устанавливайте этот пакет напрямую.** Начните с бэкенд-пакета для вашего фреймворка — он позаботится обо всём, включая подключение этих фронтенд-ресурсов.
+
+## Возможности
+
+- **Разделение тикетов** — Разделите ответ на новый самостоятельный тикет с сохранением контекста
+- **Откладывание тикетов** — Откладывайте тикеты с предустановками (1ч, 4ч, завтра, следующая неделя) и автоматическим пробуждением
+- **Сохранённые представления / пользовательские очереди** — Сохраняйте, именуйте и делитесь предустановками фильтров как многоразовыми представлениями тикетов
+- **Встраиваемый виджет поддержки** — Готовый виджет `<script>` с поиском по базе знаний, формой тикета и проверкой статуса
+- **Обновления в реальном времени** — Поддержка WebSocket (Pusher/Reverb/Soketi) с автоматическим откатом на поллинг
+- **Переключатель базы знаний** — Включайте или отключайте публичную базу знаний в настройках администратора
+- **CI: ESLint + Prettier** — Автоматическое применение стиля кода при каждом pull request
+
+## Начало работы
+
+Выберите ваш фреймворк:
+
+| Фреймворк | Репозиторий | Установка |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [Скачать escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | См. [настройка pubspec.yaml](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Каждый бэкенд-репозиторий содержит полные инструкции по настройке — команда установки, миграции, конфигурация и интеграция фронтенда.
+
+## Tailwind CSS
+
+Компоненты Escalated используют классы Tailwind CSS. Вы **должны** добавить этот пакет в конфигурацию `content` Tailwind, чтобы его классы не были удалены:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... ваши существующие пути
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Без этого интерфейс Escalated будет отрендерен, но стили, такие как фоны кнопок и цвета бейджей, будут отсутствовать.
+
+## Темы
+
+Escalated по умолчанию рендерится внутри автономного макета. Чтобы интегрировать его в систему дизайна вашего приложения, используйте `EscalatedPlugin`:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Интеграция макета
+
+Передайте компонент макета вашего приложения, и все страницы Escalated автоматически будут рендериться внутри него. Компонент макета должен принимать слот `#header` и слот по умолчанию:
+
+```vue
+<!-- Ваш макет должен поддерживать эти слоты -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Когда макет не предоставлен, Escalated использует свою встроенную навигационную панель.
+
+### Пользовательские CSS-свойства
+
+Опция `theme` устанавливает пользовательские CSS-свойства, на которые вы можете ссылаться в своих стилях:
+
+| Свойство | По умолчанию | Описание |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Основной цвет действия |
+| `--esc-primary-hover` | автозатемнение | Основной цвет при наведении |
+| `--esc-radius` | `0.5rem` | Радиус границы для полей ввода и кнопок |
+| `--esc-radius-lg` | автомасштабирование | Радиус границы для карточек и панелей |
+| `--esc-font-family` | наследуется | Переопределение семейства шрифтов |
+
+### Примеры для фреймворков
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Что в этом репозитории
+
+Все компоненты Vue 3 + Inertia.js, которые обеспечивают работу интерфейса Escalated. Они идентичны для Laravel, Rails, Django и AdonisJS — бэкенд-фреймворк рендерит их через Inertia.
+
+## 📸 Скриншоты
+
+> Скриншоты автоматически генерируются из Storybook через рабочий процесс [component-screenshots](.github/workflows/screenshots.yml).
+
+<p align="center">
+  <strong>Панель администратора (Тёмная)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Панель администратора Escalated — тёмный режим с боковой навигацией, KPI-карточками, статистикой и списком тикетов" width="800" />
+</p>
+
+<p align="center">
+  <strong>Панель администратора (Светлая)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Панель администратора Escalated — светлый режим с боковой навигацией, KPI-карточками, статистикой и списком тикетов" width="800" />
+</p>
+
+<p align="center">
+  <strong>Очередь тикетов</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Очередь тикетов Escalated — список тикетов агента с фильтрами, поиском, массовыми действиями и индикаторами SLA" width="800" />
+</p>
+
+<p align="center">
+  <strong>Панель агента</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Панель агента Escalated — верхняя навигация, статистика и очередь назначенных тикетов" width="800" />
+</p>
+
+<p align="center">
+  <strong>Детальный просмотр тикета</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Детальный просмотр тикета Escalated — ветка разговора, редактор ответа и боковая панель тикета с таймером SLA" width="800" />
+</p>
+
+### Страницы
+
+**Клиентский портал** — Самообслуживание тикетов
+- `pages/Customer/Index.vue` — Список тикетов с фильтрами статуса и поиском
+- `pages/Customer/Create.vue` — Форма нового тикета с вложениями файлов
+- `pages/Customer/Show.vue` — Детали тикета с веткой ответов
+
+**Панель агента** — Очередь тикетов и рабочие процессы
+- `pages/Agent/Dashboard.vue` — Обзор статистики и последних тикетов
+- `pages/Agent/TicketIndex.vue` — Фильтруемая очередь тикетов
+- `pages/Agent/TicketShow.vue` — Полный просмотр тикета с боковой панелью, внутренними заметками, шаблонами ответов
+
+**Панель администратора** — Конфигурация системы
+- `pages/Admin/Reports.vue` — Аналитическая панель
+- `pages/Admin/Departments/` — Управление отделами (CRUD)
+- `pages/Admin/SlaPolicies/` — Управление политиками SLA
+- `pages/Admin/EscalationRules/` — Конструктор правил эскалации
+- `pages/Admin/Tags/` — Управление тегами
+- `pages/Admin/CannedResponses/` — Шаблоны готовых ответов
+
+### Общие компоненты
+
+Переиспользуемые строительные блоки, используемые на страницах выше.
+
+| Компонент | Описание |
+|-----------|-------------|
+| `StatusBadge` | Цветной бейдж для статуса тикета |
+| `PriorityBadge` | Цветной бейдж для приоритета тикета |
+| `TicketList` | Пагинированная таблица тикетов |
+| `ReplyThread` | Хронологическое отображение ответов |
+| `ReplyComposer` | Редактор ответа/заметки с загрузкой файлов и вставкой шаблонных ответов |
+| `ActivityTimeline` | Журнал аудита событий тикета |
+| `SlaTimer` | Обратный отсчёт SLA с состояниями нарушения/предупреждения |
+| `TicketFilters` | Панель фильтров статуса, приоритета, агента, отдела |
+| `TicketSidebar` | Боковая панель деталей тикета (статус, SLA, теги, активность) |
+| `AssigneeSelect` | Выпадающий список назначения агента |
+| `TagSelect` | Множественный выбор тегов |
+| `FileDropzone` | Загрузка файлов перетаскиванием |
+| `AttachmentList` | Отображение вложений с ссылками для скачивания |
+| `StatsCard` | Карточка метрик с меткой, значением и трендом |
+| `EscalatedLayout` | Макет верхнего уровня с навигацией (поддерживает внедрение хост-макета) |
+| `BulkActionBar` | Панель инструментов для массовых операций над выбранными тикетами |
+| `QuickFilters` | Фильтр-чипы в один клик (Мои тикеты, Неназначенные, Срочные, SLA нарушен) |
+| `MacroDropdown` | Выпадающий список для применения многошаговых макросов к тикету |
+| `FollowButton` | Кнопка переключения для подписки/отписки от тикета |
+| `SatisfactionRating` | Ввод оценки CSAT от 1 до 5 звёзд с необязательным комментарием |
+| `KeyboardShortcutHelp` | Модальное окно со всеми доступными горячими клавишами |
+| `PinnedNotes` | Отображение закреплённых внутренних заметок вверху ветки |
+| `PresenceIndicator` | Индикатор реального времени, показывающий кто просматривает тикет |
+
+### Composables
+
+| Composable | Описание |
+|------------|-------------|
+| `useKeyboardShortcuts` | Регистрирует и управляет горячими клавишами для действий с тикетами |
+
+### Плагин
+
+| Экспорт | Описание |
+|--------|-------------|
+| `EscalatedPlugin` | Vue-плагин для внедрения макета и CSS-тем |
+
+## Разработка плагинов
+
+Escalated поддерживает фреймворк-независимые плагины, созданные с помощью [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk). Плагины пишутся один раз на TypeScript и работают на всех бэкендах Escalated.
+
+### Как работает система плагинов фронтенда
+
+Фронтенд использует `defineEscalatedPlugin()` для регистрации компонентов Vue — пользовательских страниц администратора, виджетов боковой панели тикетов или панелей дашборда — которые автоматически монтируются, когда плагин активен.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Как он подключается к бэкенду
+
+Бэкенд использует `definePlugin()` из [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) для обработки бизнес-логики TypeScript — подписка на хуки жизненного цикла тикетов, предоставление API-эндпоинтов и сохранение данных. Фронтенд и бэкенд входные точки работают вместе как единый npm-пакет.
+
+```typescript
+// бэкенд входная точка (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Быстрый пример: обе точки входа
+
+Опубликованный пакет плагина обычно экспортирует оба:
+
+```
+my-plugin/
+  index.ts          ← бэкенд: definePlugin() для логики TypeScript
+  frontend.ts       ← фронтенд: defineEscalatedPlugin() для компонентов Vue
+```
+
+Бэкенд-фреймворк (Laravel, Rails, Django, AdonisJS) загружает `index.ts` через [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime). Vue-приложение импортирует `frontend.ts` и регистрирует его через `app.use()`.
+
+### Установка плагинов
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Ресурсы
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — TypeScript SDK для создания плагинов
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Хост выполнения для плагинов
+- [Руководство по разработке плагинов](https://github.com/escalated-dev/escalated-docs) — Полная документация
+
+## Для мейнтейнеров пакетов
+
+Если вы создаёте новую бэкенд-интеграцию, этот пакет доступен на npm:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Импорт плагина
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Импорт отдельных компонентов
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// Или ссылка на страницы напрямую для разрешения Inertia
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Peer-зависимости: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Экосистема
+
+Это общий фронтенд для системы тикетов поддержки Escalated. Бэкенд-пакеты доступны для каждого основного фреймворка:
+
+- **[Escalated для Laravel](https://github.com/escalated-dev/escalated-laravel)** — Пакет Laravel Composer
+- **[Escalated для Rails](https://github.com/escalated-dev/escalated-rails)** — Движок Ruby on Rails
+- **[Escalated для Django](https://github.com/escalated-dev/escalated-django)** — Переиспользуемое приложение Django
+- **[Escalated для AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — Пакет AdonisJS v6
+- **[Escalated для Filament](https://github.com/escalated-dev/escalated-filament)** — Плагин панели администратора Filament v3
+- **[Общий фронтенд](https://github.com/escalated-dev/escalated)** — Компоненты UI Vue 3 + Inertia.js (вы здесь)
+
+## Лицензия
+
+MIT

--- a/docs/translations/README.tr.md
+++ b/docs/translations/README.tr.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <b>Türkçe</b> •
+  <a href="README.zh-CN.md">简体中文</a>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated, SLA takibi, yukseltme kurallari, temsilci is akislari ve musteri portali ile gomulu bir destek bilet sistemidir. Bu depo, desteklenen tum backend cercevelerinde kullanilan tum paylasilan frontend varliklarini (Vue 3 + Inertia.js) icerir.
+
+👉 **Daha fazla bilgi edinin, demolari goruntuluyin ve Bulut ile Kendi Sunucunuz seceneklerini karsilastirin:** **[https://escalated.dev](https://escalated.dev)**
+
+**Bu paketi dogrudan kurmayIn.** Cerceveniz icin backend paketiyle baslayin — bu frontend varliklarinin cekilmesi dahil her seyi halleder.
+
+## Ozellikler
+
+- **Bilet bolme** — Bir yaniti baglami koruyarak yeni bagimsiz bir bilete bolun
+- **Bilet erteleme** — On ayarlarla (1s, 4s, yarin, gelecek hafta) biletleri erteleyin ve otomatik uyandirma
+- **Kaydedilmis gorunumler / ozel kuyruklar** — Filtre on ayarlarini yeniden kullanilabilir bilet gorunumleri olarak kaydedin, adlandirin ve paylasin
+- **Gomulu destek widget'i** — KB aramasi, bilet formu ve durum kontrolu iceren hazir `<script>` widget'i
+- **Gercek zamanli guncellemeler** — WebSocket destegi (Pusher/Reverb/Soketi) ile otomatik yoklama geri donusu
+- **Bilgi bankasi degistirici** — Yonetici ayarlarindan genel bilgi bankasini etkinlestirin veya devre disi birakin
+- **CI: ESLint + Prettier** — Her pull request'te otomatik kod stili uygulamasi
+
+## Baslangic
+
+Cercevenizi secin:
+
+| Cerceve | Depo | Kurulum |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [escalated.zip indir](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | Bkz. [pubspec.yaml kurulumu](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+Her backend deposunda tam kurulum talimatlari vardir — kurulum komutu, migrasyon, yapilandirma ve frontend entegrasyonu.
+
+## Tailwind CSS
+
+Escalated bilesenleri Tailwind CSS siniflarini kullanir. Bu paketin siniflarinin temizlenmemesi icin Tailwind `content` yapilandirmaniza eklemeniz **gerekir**:
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... mevcut yollariniz
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+Bu olmadan, Escalated arayuzu olusturulur ancak dugme arka planlari ve rozet renkleri gibi stiller eksik olur.
+
+## Tema
+
+Escalated varsayilan olarak bagimsiz bir duzen icinde olusturulur. Uygulamanizin tasarim sistemine entegre etmek icin `EscalatedPlugin` kullanin:
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### Duzen Entegrasyonu
+
+Uygulamanizin duzen bilesenini gecirin ve tum Escalated sayfalari otomatik olarak icinde olusturulur. Duzen bileseni bir `#header` yuvasi ve varsayilan yuva kabul etmelidir:
+
+```vue
+<!-- Duzeniniz bu yuvalari desteklemelidir -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+Duzen saglanamazsa, Escalated kendi yerlesik gezinme cubugunu kullanir.
+
+### Ozel CSS Ozellikleri
+
+`theme` secenegi, kendi stillerinizde referans verebileceginiz ozel CSS ozelliklerini ayarlar:
+
+| Ozellik | Varsayilan | Aciklama |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | Birincil eylem rengi |
+| `--esc-primary-hover` | otomatik koyulastirma | Birincil uzerine gelme rengi |
+| `--esc-radius` | `0.5rem` | Giris alanlari ve dugmeler icin kenar yaricapi |
+| `--esc-radius-lg` | otomatik olcekleme | Kartlar ve paneller icin kenar yaricapi |
+| `--esc-font-family` | miras | Yazi tipi ailesi gecersiz kilma |
+
+### Cerceve Ornekleri
+
+**Laravel** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3):
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## Bu Depoda Neler Var
+
+Escalated arayuzunu calistiran tum Vue 3 + Inertia.js bilesenleri. Bunlar Laravel, Rails, Django ve AdonisJS genelinde aynidir — backend cercevesi bunlari Inertia araciligiyla olusturur.
+
+## 📸 Ekran Goruntuleri
+
+> Ekran goruntuleri [component-screenshots](.github/workflows/screenshots.yml) is akisi araciligiyla Storybook'tan otomatik olarak olusturulur.
+
+<p align="center">
+  <strong>Yonetici Paneli (Karanlik)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Escalated Yonetici Paneli — kenar cubugu gezintisi, KPI kartlari, istatistikler ve bilet listesi ile karanlik mod" width="800" />
+</p>
+
+<p align="center">
+  <strong>Yonetici Paneli (Acik)</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Escalated Yonetici Paneli — kenar cubugu gezintisi, KPI kartlari, istatistikler ve bilet listesi ile acik mod" width="800" />
+</p>
+
+<p align="center">
+  <strong>Bilet Kuyrugu</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Escalated Bilet Kuyrugu — filtreler, arama, toplu eylemler ve SLA gostergeleri ile temsilci bilet listesi" width="800" />
+</p>
+
+<p align="center">
+  <strong>Temsilci Paneli</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Escalated Temsilci Paneli — ust gezinme, istatistikler ve atanmis bilet kuyrugu" width="800" />
+</p>
+
+<p align="center">
+  <strong>Bilet Detay Gorunumu</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Escalated Bilet Detay Gorunumu — konusma dizisi, yanit duzenleyici ve SLA zamanlayicili bilet kenar cubugu" width="800" />
+</p>
+
+### Sayfalar
+
+**Musteri Portali** — Self-servis bilet yonetimi
+- `pages/Customer/Index.vue` — Durum filtreleri ve arama ile bilet listesi
+- `pages/Customer/Create.vue` — Dosya ekleri ile yeni bilet formu
+- `pages/Customer/Show.vue` — Yanit dizisi ile bilet detayi
+
+**Temsilci Panosu** — Bilet kuyrugu ve is akislari
+- `pages/Agent/Dashboard.vue` — Istatistik ozeti ve son biletler
+- `pages/Agent/TicketIndex.vue` — Filtrelenebilir bilet kuyrugu
+- `pages/Agent/TicketShow.vue` — Kenar cubugu, dahili notlar, hazir yanitlarla tam bilet gorunumu
+
+**Yonetici Paneli** — Sistem yapilandirmasi
+- `pages/Admin/Reports.vue` — Analiz panosu
+- `pages/Admin/Departments/` — Departman yonetimi (CRUD)
+- `pages/Admin/SlaPolicies/` — SLA politika yonetimi
+- `pages/Admin/EscalationRules/` — Yukseltme kurali olusturucu
+- `pages/Admin/Tags/` — Etiket yonetimi
+- `pages/Admin/CannedResponses/` — Hazir yanit sablonlari
+
+### Paylasilan Bilesenler
+
+Yukaridaki sayfalarda kullanilan yeniden kullanilabilir yapi bloklari.
+
+| Bilesen | Aciklama |
+|-----------|-------------|
+| `StatusBadge` | Bilet durumu icin renkli rozet |
+| `PriorityBadge` | Bilet onceligi icin renkli rozet |
+| `TicketList` | Sayfalandirilmis bilet tablosu |
+| `ReplyThread` | Kronolojik yanit gorunumu |
+| `ReplyComposer` | Dosya yukleme ve hazir yanit ekleme ile yanit/not duzenleyici |
+| `ActivityTimeline` | Bilet olaylarinin denetim gunlugu |
+| `SlaTimer` | Ihlal/uyari durumlariyla SLA geri sayim |
+| `TicketFilters` | Durum, oncelik, temsilci, departman filtre cubugu |
+| `TicketSidebar` | Bilet detay kenar cubugu (durum, SLA, etiketler, aktivite) |
+| `AssigneeSelect` | Temsilci atama acilir menusu |
+| `TagSelect` | Coklu secim etiket secici |
+| `FileDropzone` | Surukle-birak dosya yukleme |
+| `AttachmentList` | Indirme baglantilari ile dosya eki gorunumu |
+| `StatsCard` | Etiket, deger ve egilim ile metrik karti |
+| `EscalatedLayout` | Gezinmeli ust duzey duzen (ana bilgisayar duzen enjeksiyonunu destekler) |
+| `BulkActionBar` | Secili biletlerde toplu islemler icin arac cubugu |
+| `QuickFilters` | Tek tikla filtre cipleri (Biletlerim, Atanmamis, Acil, SLA Ihlali) |
+| `MacroDropdown` | Bir bilete cok adimli makrolari uygulamak icin acilir menu |
+| `FollowButton` | Bir bileti takip etme/takibi birakma degistirme dugmesi |
+| `SatisfactionRating` | Istege bagli yorum ile 1-5 yildiz CSAT derecelendirme girisi |
+| `KeyboardShortcutHelp` | Tum mevcut klavye kisayollarini gosteren modal kaplama |
+| `PinnedNotes` | Dizinin ustunde sabitlenmis dahili notlarin gorunumu |
+| `PresenceIndicator` | Bir bileti kimin goruntuledigini gosteren gercek zamanli gosterge |
+
+### Composables
+
+| Composable | Aciklama |
+|------------|-------------|
+| `useKeyboardShortcuts` | Bilet eylemleri icin klavye kisayollarini kaydeder ve yonetir |
+
+### Eklenti
+
+| Disari Aktarma | Aciklama |
+|--------|-------------|
+| `EscalatedPlugin` | Duzen enjeksiyonu ve CSS tema ayari icin Vue eklentisi |
+
+## Eklenti Gelistirme
+
+Escalated, [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) ile olusturulan cerceve bagimsiz eklentileri destekler. Eklentiler TypeScript'te bir kez yazilir ve tum Escalated backend'lerinde calisir.
+
+### Frontend Eklenti Sistemi Nasil Calisir
+
+Frontend, Vue bilesenlerini kaydetmek icin `defineEscalatedPlugin()` kullanir — ozel yonetici sayfalari, bilet kenar cubugu widget'leri veya pano panelleri — eklenti aktif oldugunda otomatik olarak montajlanir.
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### Backend'e Nasil Baglanir
+
+Backend, TypeScript is mantigi islemek icin [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk)'dan `definePlugin()` kullanir — bilet yasam dongusu kancalarina abone olma, API endpointlerini aciga cikarma ve verileri kalici hale getirme. Frontend ve backend girisleri tek bir npm paketi olarak birlikte calisir.
+
+```typescript
+// backend girisi (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### Hizli Ornek: Her Iki Giris Noktasi
+
+Yayinlanmis bir eklenti paketi genellikle her ikisini de disari aktarir:
+
+```
+my-plugin/
+  index.ts          ← backend: TypeScript mantigi icin definePlugin()
+  frontend.ts       ← frontend: Vue bilesenleri icin defineEscalatedPlugin()
+```
+
+Backend cercevesi (Laravel, Rails, Django, AdonisJS) `index.ts`'yi [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) araciligiyla yukler. Vue uygulamasi `frontend.ts`'yi ice aktarir ve `app.use()` ile kaydeder.
+
+### Eklenti Kurulumu
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### Kaynaklar
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — Eklenti olusturma icin TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — Eklentiler icin calisma zamani ana bilgisayari
+- [Eklenti Gelistirme Kilavuzu](https://github.com/escalated-dev/escalated-docs) — Tam dokumantasyon
+
+## Paket Bakimcilari Icin
+
+Yeni bir backend entegrasyonu olusturuyorsaniz, bu paket npm'de mevcuttur:
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// Eklentiyi ice aktar
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// Bireysel bilesenleri ice aktar
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// Veya Inertia cozumlemesi icin sayfalara dogrudan basvur
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+Peer bagimliliklari: `vue` ^3.3.0, `@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## Ekosistem
+
+Bu, Escalated destek bilet sistemi icin paylasilan frontend'dir. Her buyuk cerceve icin backend paketleri mevcuttur:
+
+- **[Escalated icin Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer paketi
+- **[Escalated icin Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails motoru
+- **[Escalated icin Django](https://github.com/escalated-dev/escalated-django)** — Yeniden kullanilabilir Django uygulamasi
+- **[Escalated icin AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 paketi
+- **[Escalated icin Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 yonetici paneli eklentisi
+- **[Paylasilan Frontend](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI bilesenleri (buradasiniz)
+
+## Lisans
+
+MIT

--- a/docs/translations/README.zh-CN.md
+++ b/docs/translations/README.zh-CN.md
@@ -1,0 +1,353 @@
+<p align="center">
+  <a href="README.ar.md">العربية</a> •
+  <a href="README.de.md">Deutsch</a> •
+  <a href="../../README.md">English</a> •
+  <a href="README.es.md">Español</a> •
+  <a href="README.fr.md">Français</a> •
+  <a href="README.it.md">Italiano</a> •
+  <a href="README.ja.md">日本語</a> •
+  <a href="README.ko.md">한국어</a> •
+  <a href="README.nl.md">Nederlands</a> •
+  <a href="README.pl.md">Polski</a> •
+  <a href="README.pt-BR.md">Português (BR)</a> •
+  <a href="README.ru.md">Русский</a> •
+  <a href="README.tr.md">Türkçe</a> •
+  <b>简体中文</b>
+</p>
+
+<h1>
+  <img src="https://escalated.dev/apple-touch-icon.png" width="28" style="vertical-align:middle;" />
+  Escalated
+</h1>
+
+[![Tests](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml/badge.svg)](https://github.com/escalated-dev/escalated/actions/workflows/run-tests.yml)
+[![npm](https://img.shields.io/npm/v/@escalated-dev/escalated)](https://www.npmjs.com/package/@escalated-dev/escalated)
+[![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+Escalated 是一个可嵌入的支持工单系统，具备 SLA 跟踪、升级规则、客服工作流和客户门户。此仓库包含所有支持的后端框架中使用的共享前端资源（Vue 3 + Inertia.js）。
+
+👉 **了解更多、查看演示、比较云端与自托管方案，请访问** **[https://escalated.dev](https://escalated.dev)**
+
+**请勿直接安装此包。** 请从您框架的后端包开始 - 它会处理一切，包括引入这些前端资源。
+
+## 功能特性
+
+- **工单拆分** — 将回复拆分为新的独立工单，同时保留上下文
+- **工单暂停** — 使用预设（1小时、4小时、明天、下周）暂停工单并自动唤醒
+- **保存的视图 / 自定义队列** — 保存、命名和共享筛选预设作为可重用的工单视图
+- **可嵌入的支持小部件** — 即插即用的 `<script>` 小部件，包含知识库搜索、工单表单和状态检查
+- **实时更新** — WebSocket 支持（Pusher/Reverb/Soketi），带自动轮询回退
+- **知识库开关** — 从管理设置中启用或禁用公共知识库
+- **CI：ESLint + Prettier** — 每次拉取请求自动执行代码风格检查
+
+## 快速开始
+
+选择您的框架：
+
+| 框架 | 仓库 | 安装 |
+|-----------|------|---------|
+| **Laravel** | [escalated-dev/escalated-laravel](https://github.com/escalated-dev/escalated-laravel) | `composer require escalated-dev/escalated-laravel` |
+| **Rails** | [escalated-dev/escalated-rails](https://github.com/escalated-dev/escalated-rails) | `gem "escalated"` |
+| **Django** | [escalated-dev/escalated-django](https://github.com/escalated-dev/escalated-django) | `pip install escalated-django` |
+| **AdonisJS** | [escalated-dev/escalated-adonis](https://github.com/escalated-dev/escalated-adonis) | `npm install @escalated-dev/escalated-adonis` |
+| **WordPress** | [escalated-dev/escalated-wordpress](https://github.com/escalated-dev/escalated-wordpress) | [下载 escalated.zip](https://github.com/escalated-dev/escalated-wordpress/releases/latest) |
+| **Filament** | [escalated-dev/escalated-filament](https://github.com/escalated-dev/escalated-filament) | `composer require escalated-dev/escalated-filament` |
+| **React Native** | [escalated-dev/escalated-react-native](https://github.com/escalated-dev/escalated-react-native) | `npm install @escalated-dev/escalated-react-native` |
+| **Flutter** | [escalated-dev/escalated-flutter](https://github.com/escalated-dev/escalated-flutter) | 参见 [pubspec.yaml 设置](https://github.com/escalated-dev/escalated-flutter#quick-start) |
+
+每个后端仓库都有完整的设置说明 — 安装命令、迁移、配置和前端集成。
+
+## Tailwind CSS
+
+Escalated 组件使用 Tailwind CSS 类。您**必须**将此包添加到 Tailwind 的 `content` 配置中，以防止其类被清除：
+
+```js
+// tailwind.config.js
+export default {
+    content: [
+        // ... 您现有的路径
+        './node_modules/@escalated-dev/escalated/src/**/*.vue',
+    ],
+}
+```
+
+如果不这样做，Escalated UI 会渲染但按钮背景和徽章颜色等样式将缺失。
+
+## 主题定制
+
+Escalated 默认在独立布局中渲染。要将其集成到您应用的设计系统中，请使用 `EscalatedPlugin`：
+
+```js
+import { createApp } from 'vue'
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/Layouts/AppLayout.vue'
+
+const app = createApp(...)
+
+app.use(EscalatedPlugin, {
+    layout: AppLayout,
+    theme: {
+        primary: '#3b82f6',
+        radius: '0.75rem',
+    }
+})
+```
+
+### 布局集成
+
+传入您应用的布局组件，所有 Escalated 页面将自动在其中渲染。布局组件必须接受 `#header` 插槽和默认插槽：
+
+```vue
+<!-- 您的布局必须支持这些插槽 -->
+<template>
+    <div>
+        <nav>...</nav>
+        <header><slot name="header" /></header>
+        <main><slot /></main>
+    </div>
+</template>
+```
+
+当未提供布局时，Escalated 使用其自带的导航栏。
+
+### CSS 自定义属性
+
+`theme` 选项设置您可以在自己样式中引用的 CSS 自定义属性：
+
+| 属性 | 默认值 | 描述 |
+|----------|---------|-------------|
+| `--esc-primary` | `#4f46e5` | 主要操作颜色 |
+| `--esc-primary-hover` | 自动加深 | 主要悬停颜色 |
+| `--esc-radius` | `0.5rem` | 输入框和按钮的边框圆角 |
+| `--esc-radius-lg` | 自动缩放 | 卡片和面板的边框圆角 |
+| `--esc-font-family` | 继承 | 字体族覆盖 |
+
+### 框架示例
+
+**Laravel** (Inertia + Vue 3)：
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AuthenticatedLayout })
+```
+
+**Rails** (Inertia + Vue 3)：
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+**Django** (Inertia + Vue 3)：
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import BaseLayout from '@/layouts/BaseLayout.vue'
+
+app.use(EscalatedPlugin, { layout: BaseLayout })
+```
+
+**AdonisJS** (Inertia + Vue 3)：
+```js
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+import AppLayout from '@/layouts/AppLayout.vue'
+
+app.use(EscalatedPlugin, { layout: AppLayout })
+```
+
+## 仓库内容
+
+驱动 Escalated UI 的所有 Vue 3 + Inertia.js 组件。这些组件在 Laravel、Rails、Django 和 AdonisJS 中完全相同 — 后端框架通过 Inertia 进行渲染。
+
+## 📸 截图
+
+> 截图通过 [component-screenshots](.github/workflows/screenshots.yml) 工作流从 Storybook 自动生成。
+
+<p align="center">
+  <strong>管理面板（深色）</strong><br/>
+  <img src="../../docs/assets/escalated_admin_1.png" alt="Escalated 管理面板 — 深色模式，带侧边栏导航、KPI 卡片、统计数据和工单列表" width="800" />
+</p>
+
+<p align="center">
+  <strong>管理面板（浅色）</strong><br/>
+  <img src="../../docs/assets/escalated_admin_3.png" alt="Escalated 管理面板 — 浅色模式，带侧边栏导航、KPI 卡片、统计数据和工单列表" width="800" />
+</p>
+
+<p align="center">
+  <strong>工单队列</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_list.png" alt="Escalated 工单队列 — 客服工单列表，带筛选、搜索、批量操作和 SLA 指标" width="800" />
+</p>
+
+<p align="center">
+  <strong>客服面板</strong><br/>
+  <img src="../../docs/assets/escalated_admin_2.png" alt="Escalated 客服面板 — 顶部导航、统计数据和已分配工单队列" width="800" />
+</p>
+
+<p align="center">
+  <strong>工单详情视图</strong><br/>
+  <img src="../../docs/assets/escalated_ticket_view.png" alt="Escalated 工单详情视图 — 对话线程、回复编辑器和带 SLA 计时器的工单侧边栏" width="800" />
+</p>
+
+### 页面
+
+**客户门户** — 自助工单管理
+- `pages/Customer/Index.vue` — 带状态筛选和搜索的工单列表
+- `pages/Customer/Create.vue` — 带文件附件的新建工单表单
+- `pages/Customer/Show.vue` — 带回复线程的工单详情
+
+**客服仪表盘** — 工单队列和工作流
+- `pages/Agent/Dashboard.vue` — 统计概览和最近工单
+- `pages/Agent/TicketIndex.vue` — 可筛选的工单队列
+- `pages/Agent/TicketShow.vue` — 完整工单视图，带侧边栏、内部备注、预设回复
+
+**管理面板** — 系统配置
+- `pages/Admin/Reports.vue` — 分析仪表盘
+- `pages/Admin/Departments/` — 部门管理（CRUD）
+- `pages/Admin/SlaPolicies/` — SLA 策略管理
+- `pages/Admin/EscalationRules/` — 升级规则构建器
+- `pages/Admin/Tags/` — 标签管理
+- `pages/Admin/CannedResponses/` — 预设回复模板
+
+### 共享组件
+
+在上述页面中使用的可重用构建模块。
+
+| 组件 | 描述 |
+|-----------|-------------|
+| `StatusBadge` | 工单状态彩色徽章 |
+| `PriorityBadge` | 工单优先级彩色徽章 |
+| `TicketList` | 分页工单表格 |
+| `ReplyThread` | 按时间顺序显示回复 |
+| `ReplyComposer` | 回复/备注编辑器，带文件上传和预设回复插入 |
+| `ActivityTimeline` | 工单事件审计日志 |
+| `SlaTimer` | 带违规/警告状态的 SLA 倒计时 |
+| `TicketFilters` | 状态、优先级、客服、部门筛选栏 |
+| `TicketSidebar` | 工单详情侧边栏（状态、SLA、标签、活动） |
+| `AssigneeSelect` | 客服分配下拉菜单 |
+| `TagSelect` | 多选标签选择器 |
+| `FileDropzone` | 拖放文件上传 |
+| `AttachmentList` | 带下载链接的文件附件显示 |
+| `StatsCard` | 带标签、数值和趋势的指标卡片 |
+| `EscalatedLayout` | 带导航的顶层布局（支持宿主布局注入） |
+| `BulkActionBar` | 选中工单的批量操作工具栏 |
+| `QuickFilters` | 一键筛选标签（我的工单、未分配、紧急、SLA 违规） |
+| `MacroDropdown` | 对工单应用多步骤宏的下拉菜单 |
+| `FollowButton` | 关注/取消关注工单的切换按钮 |
+| `SatisfactionRating` | 1-5 星 CSAT 评分输入，带可选评论 |
+| `KeyboardShortcutHelp` | 显示所有可用键盘快捷键的模态覆盖层 |
+| `PinnedNotes` | 在线程顶部显示置顶的内部备注 |
+| `PresenceIndicator` | 实时指示器，显示谁在查看工单 |
+
+### 组合式函数
+
+| 组合式函数 | 描述 |
+|------------|-------------|
+| `useKeyboardShortcuts` | 注册和管理工单操作的键盘快捷键 |
+
+### 插件
+
+| 导出 | 描述 |
+|--------|-------------|
+| `EscalatedPlugin` | 用于布局注入和 CSS 主题的 Vue 插件 |
+
+## 插件开发
+
+Escalated 支持使用 [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) 构建的框架无关插件。插件使用 TypeScript 编写一次，即可在所有 Escalated 后端上运行。
+
+### 前端插件系统的工作原理
+
+前端使用 `defineEscalatedPlugin()` 注册 Vue 组件 — 自定义管理页面、工单侧边栏小部件或仪表盘面板 — 当插件激活时会自动挂载。
+
+```typescript
+import { defineEscalatedPlugin } from '@escalated-dev/escalated'
+import MySettingsPage from './MySettingsPage.vue'
+
+export default defineEscalatedPlugin({
+  name: 'my-plugin',
+  pages: {
+    'admin/my-plugin/settings': MySettingsPage,
+  },
+})
+```
+
+### 如何连接到后端
+
+后端使用 [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) 的 `definePlugin()` 处理 TypeScript 业务逻辑 — 订阅工单生命周期钩子、暴露 API 端点和持久化数据。前端和后端入口作为单个 npm 包协同工作。
+
+```typescript
+// 后端入口 (index.ts)
+import { definePlugin } from '@escalated-dev/plugin-sdk'
+
+export default definePlugin({
+  name: 'my-plugin',
+  version: '1.0.0',
+  actions: {
+    'ticket.created': async (event, ctx) => {
+      ctx.log.info('New ticket!', event)
+    },
+  },
+})
+```
+
+### 快速示例：两个入口点
+
+发布的插件包通常导出两者：
+
+```
+my-plugin/
+  index.ts          ← 后端：用于 TypeScript 逻辑的 definePlugin()
+  frontend.ts       ← 前端：用于 Vue 组件的 defineEscalatedPlugin()
+```
+
+后端框架（Laravel、Rails、Django、AdonisJS）通过 [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) 加载 `index.ts`。Vue 应用导入 `frontend.ts` 并使用 `app.use()` 注册。
+
+### 安装插件
+
+```bash
+npm install @escalated-dev/plugin-slack
+npm install @escalated-dev/plugin-jira
+```
+
+### 资源
+
+- [Plugin SDK](https://github.com/escalated-dev/escalated-plugin-sdk) — 用于构建插件的 TypeScript SDK
+- [Plugin Runtime](https://github.com/escalated-dev/escalated-plugin-runtime) — 插件的运行时宿主
+- [插件开发指南](https://github.com/escalated-dev/escalated-docs) — 完整文档
+
+## 包维护者指南
+
+如果您正在构建新的后端集成，此包可在 npm 上获取：
+
+```bash
+npm install @escalated-dev/escalated
+```
+
+```js
+// 导入插件
+import { EscalatedPlugin } from '@escalated-dev/escalated'
+
+// 导入单个组件
+import { StatusBadge, SlaTimer } from '@escalated-dev/escalated'
+
+// 或直接引用页面用于 Inertia 解析
+import CustomerIndex from '@escalated-dev/escalated/pages/Customer/Index.vue'
+```
+
+对等依赖：`vue` ^3.3.0、`@inertiajs/vue3` ^1.0.0 || ^2.0.0
+
+## 生态系统
+
+这是 Escalated 支持工单系统的共享前端。每个主要框架都有后端包可用：
+
+- **[Escalated for Laravel](https://github.com/escalated-dev/escalated-laravel)** — Laravel Composer 包
+- **[Escalated for Rails](https://github.com/escalated-dev/escalated-rails)** — Ruby on Rails 引擎
+- **[Escalated for Django](https://github.com/escalated-dev/escalated-django)** — Django 可重用应用
+- **[Escalated for AdonisJS](https://github.com/escalated-dev/escalated-adonis)** — AdonisJS v6 包
+- **[Escalated for Filament](https://github.com/escalated-dev/escalated-filament)** — Filament v3 管理面板插件
+- **[共享前端](https://github.com/escalated-dev/escalated)** — Vue 3 + Inertia.js UI 组件（您在这里）
+
+## 许可证
+
+MIT


### PR DESCRIPTION
## Summary
- Add translated README files in `docs/translations/` for 13 languages: Arabic, German, Spanish, French, Italian, Japanese, Korean, Dutch, Polish, Brazilian Portuguese, Russian, Turkish, and Chinese Simplified
- Add language selector bar at the top of the main README.md
- Each translated README includes the same language selector with the current language bolded

## Test plan
- [ ] Verify language selector links work in the main README
- [ ] Verify each translated file has correct language selector with bold current language
- [ ] Verify English links back to ../../README.md from translation files