### PR TITLE
fix: sanitize HTML to prevent XSS vulnerabilities

### DIFF
--- a/src/components/ChatBubble.vue
+++ b/src/components/ChatBubble.vue
@@ -2,6 +2,7 @@
 import { computed, inject } from 'vue';
 import { timeAgo } from '../utils/formatting';
 import { highlightMentions } from '../utils/mentionHighlight';
+import { sanitizeHtml } from '../utils/sanitizeHtml';
 
 const props = defineProps({
     message: { type: Object, required: true },
@@ -97,7 +98,10 @@ const isInternalNote = computed(() => props.message.is_internal_note);
                 <span v-if="isInternalNote" class="mb-1 block text-[10px] font-semibold uppercase opacity-70">
                     Internal Note
                 </span>
-                <p class="whitespace-pre-wrap break-words" v-html="highlightMentions(message.body || '', escDark)"></p>
+                <p
+                    class="whitespace-pre-wrap break-words"
+                    v-html="highlightMentions(sanitizeHtml(message.body || ''), escDark)"
+                ></p>
 
                 <!-- Attachments -->
                 <div v-if="message.attachments?.length" class="mt-2 space-y-1">

--- a/src/components/ReplyThread.vue
+++ b/src/components/ReplyThread.vue
@@ -27,9 +27,8 @@ function closeSplitDialog() {
 }
 
 function stripHtml(html) {
-    const tmp = document.createElement('div');
-    tmp.innerHTML = html;
-    return tmp.textContent || tmp.innerText || '';
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return doc.body.textContent || '';
 }
 
 const escDark = inject(

--- a/src/utils/mentionHighlight.js
+++ b/src/utils/mentionHighlight.js
@@ -1,4 +1,11 @@
 /**
+ * HTML-encode a string to prevent injection via mention names.
+ */
+function escapeHtml(str) {
+    return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+/**
  * Replace @{Name} patterns in text with styled mention badges.
  *
  * @param {string} html - The HTML or text content
@@ -12,6 +19,6 @@ export function highlightMentions(html, dark = false) {
         ? 'inline-flex items-center rounded-full bg-cyan-500/15 px-1.5 py-0.5 text-xs font-medium text-cyan-400 ring-1 ring-cyan-500/20'
         : 'inline-flex items-center rounded-full bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700 ring-1 ring-blue-200';
 
-    // Replace @{Name} with styled pill
-    return html.replace(/@\{([^}]+)\}/g, `<span class="${pillClass}">@$1</span>`);
+    // Replace @{Name} with styled pill, encoding the name to prevent injection
+    return html.replace(/@\{([^}]+)\}/g, (match, name) => `<span class="${pillClass}">@${escapeHtml(name)}</span>`);
 }

--- a/src/widget/EscalatedWidget.vue
+++ b/src/widget/EscalatedWidget.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, watch, onMounted } from 'vue';
+import { sanitizeHtml } from '../utils/sanitizeHtml';
 
 const props = defineProps({
     baseUrl: { type: String, default: '' },
@@ -471,7 +472,7 @@ function formatDate(iso) {
                         <template v-else>
                             <h3>{{ selectedArticle.title }}</h3>
                             <!-- eslint-disable-next-line vue/no-v-html -->
-                            <div class="esc-w-article-body" v-html="selectedArticle.body"></div>
+                            <div class="esc-w-article-body" v-html="sanitizeHtml(selectedArticle.body)"></div>
                         </template>
                     </div>
                 </template>
@@ -785,7 +786,7 @@ function formatDate(iso) {
                                 <span class="esc-w-reply-time">{{ formatDate(reply.created_at) }}</span>
                             </div>
                             <!-- eslint-disable-next-line vue/no-v-html -->
-                            <div class="esc-w-reply-body" v-html="reply.body"></div>
+                            <div class="esc-w-reply-body" v-html="sanitizeHtml(reply.body)"></div>
                         </div>
                     </div>
                     <div v-else class="esc-w-empty">No replies yet.</div>


### PR DESCRIPTION
## Summary
- **CRITICAL**: Sanitize `v-html` output in `EscalatedWidget.vue` (article body and reply body) using `sanitizeHtml()` to prevent stored XSS
- **HIGH**: Sanitize message body in `ChatBubble.vue` before passing to `highlightMentions()` to prevent XSS via chat messages
- **HIGH**: HTML-encode captured mention names in `mentionHighlight.js` to prevent injection via crafted `@{Name}` patterns
- **LOW**: Replace `innerHTML`-based `stripHtml()` in `ReplyThread.vue` with safer `DOMParser` approach

## Test plan
- [x] All 519 vitest tests pass
- [x] ESLint passes with zero warnings
- [x] Prettier formatting verified