### PR TITLE
fix: compute attachment download URL when url is missing

### DIFF
--- a/src/components/AttachmentList.vue
+++ b/src/components/AttachmentList.vue
@@ -22,6 +22,18 @@ function iconForMime(mime) {
     if (mime === 'application/pdf') return '📄';
     return '📎';
 }
+
+function attachmentUrl(attachment) {
+    if (attachment.url) return attachment.url;
+    if (typeof window.route === 'function') {
+        try {
+            return window.route('escalated.attachments.download', attachment.id);
+        } catch {
+            // route not registered
+        }
+    }
+    return `/escalated/attachments/${attachment.id}/download`;
+}
 </script>
 
 <template>
@@ -36,7 +48,7 @@ function iconForMime(mime) {
         >
             <span>{{ iconForMime(attachment.mime_type) }}</span>
             <a
-                :href="attachment.url"
+                :href="attachmentUrl(attachment)"
                 target="_blank"
                 :class="[
                     'flex-1 truncate font-medium hover:underline',

--- a/src/components/ChatBubble.vue
+++ b/src/components/ChatBubble.vue
@@ -15,6 +15,18 @@ const escDark = inject(
     computed(() => false),
 );
 
+function attachmentUrl(att) {
+    if (att.url) return att.url;
+    if (typeof window.route === 'function') {
+        try {
+            return window.route('escalated.attachments.download', att.id);
+        } catch {
+            // route not registered
+        }
+    }
+    return `/escalated/attachments/${att.id}/download`;
+}
+
 const initials = computed(() => {
     const name = props.message.author?.name || 'U';
     return name
@@ -104,7 +116,7 @@ const isInternalNote = computed(() => props.message.is_internal_note);
                     <a
                         v-for="att in message.attachments"
                         :key="att.id || att.url"
-                        :href="att.url"
+                        :href="attachmentUrl(att)"
                         target="_blank"
                         rel="noopener"
                         :class="[


### PR DESCRIPTION
## Summary
- Fixes #26 — attachment links resolve to `undefined` because the Laravel backend doesn't include `url` in the serialized attachment data
- `AttachmentList` and `ChatBubble` now compute a download URL from the attachment `id` when `url` is absent, using the Ziggy `route()` helper with a conventional path fallback (`/escalated/attachments/{id}/download`)

## Note
The backend Laravel package should also be updated to include `url` in the Attachment model's `$appends` array (or API resource) so the URL is sent directly. This frontend fix provides a resilient fallback.

## Test plan
- [x] All 519 existing tests pass
- [ ] Verify attachment links work with the Laravel backend when `url` is missing from the response
- [ ] Verify attachment links still work when `url` is provided by the backend