### PR TITLE
feat(demo): Playwright + ffmpeg pipeline that publishes the README GIF

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,117 @@
+name: Generate Demo GIF
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/demo-server.js'
+      - 'scripts/generate-demo.js'
+      - '.github/workflows/demo.yml'
+  pull_request:
+    paths:
+      - 'scripts/demo-server.js'
+      - 'scripts/generate-demo.js'
+      - '.github/workflows/demo.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Cancel in-flight runs of this workflow on the same ref so a fast-following
+# push doesn't queue a stale GIF.
+concurrency:
+  group: demo-gif-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate-demo:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: node_modules/.bin/playwright install chromium --with-deps
+
+      - name: Start demo server
+        run: |
+          node scripts/demo-server.js &
+          echo "APP_PID=$!" >> "$GITHUB_ENV"
+          # Poll for readiness (max 30s); fail loudly if the server never binds.
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000 -o /dev/null; then
+              echo "[ready] Demo server up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Demo server did not become ready within 30s"
+          exit 1
+        env:
+          PORT: 3000
+
+      - name: Generate demo GIF
+        run: node scripts/generate-demo.js
+        env:
+          DEMO_BASE_URL: http://localhost:3000
+
+      - name: Stop demo server
+        if: always()
+        run: |
+          if [ -n "${APP_PID:-}" ]; then
+            kill "$APP_PID" 2>/dev/null || true
+          fi
+
+      - name: Verify GIF was generated
+        run: |
+          GIF=".github/profile/demo.gif"
+          if [ ! -f "$GIF" ]; then
+            echo "::error::Expected $GIF was not produced"
+            exit 1
+          fi
+          SIZE=$(stat -c%s "$GIF")
+          echo "[verify] $GIF size: $SIZE bytes"
+          if [ "$SIZE" -lt 50000 ]; then
+            echo "::error::Generated GIF is implausibly small ($SIZE bytes); recording flow likely failed"
+            exit 1
+          fi
+          if [ "$SIZE" -gt 5242880 ]; then
+            echo "::warning::Generated GIF exceeds 5MB target ($SIZE bytes); consider lowering fps or scale in scripts/generate-demo.js"
+          fi
+
+      # Always upload the GIF as a workflow artifact so PR runs (which never
+      # commit back) still have a downloadable preview.
+      - name: Upload GIF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-gif
+          path: .github/profile/demo.gif
+          retention-days: 14
+
+      # Only commit on push-to-main runs so PR runs don't try to push.
+      - name: Commit updated GIF
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'chore: update demo GIF [skip ci]'
+          file_pattern: '.github/profile/demo.gif'
+          commit_user_name: 'github-actions[bot]'
+          commit_user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.log
 storybook-static/
 screenshot-results/
+# Demo-recording intermediates (the produced GIF is committed to .github/profile/)
+recordings/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@
 [![Vue 3](https://img.shields.io/badge/vue-3.x-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+<p align="center">
+  <img src=".github/profile/demo.gif" alt="Escalated demo: filing a ticket and replying from the agent inbox" width="800" />
+</p>
+
 Escalated is an embeddable support ticket system with SLA tracking, escalation rules, agent workflows, and a customer portal. This repo contains all the shared frontend assets (Vue 3 + Inertia.js) used across every supported backend framework.
 
 👉 **Learn more, view demos, and compare Cloud vs Self-Hosted options at** **[https://escalated.dev](https://escalated.dev)**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,6 +47,21 @@ export default [
         },
     },
     {
+        // Node-side scripts (demo recording pipeline, build helpers).
+        files: ['scripts/**/*.js'],
+        languageOptions: {
+            globals: {
+                process: 'readonly',
+                console: 'readonly',
+                setTimeout: 'readonly',
+                clearTimeout: 'readonly',
+                Buffer: 'readonly',
+                __dirname: 'readonly',
+                __filename: 'readonly',
+            },
+        },
+    },
+    {
         ignores: ['node_modules/', 'dist/', 'storybook-static/', 'screenshots/', 'playwright-screenshots.config.js'],
     },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,18 +18,21 @@
         "@vitejs/plugin-vue": "^5.0.0",
         "@vue/test-utils": "^2.4.0",
         "autoprefixer": "^10.4.20",
+        "concurrently": "^9.0.0",
         "eslint": "^10.0.1",
         "eslint-plugin-storybook": "^10.2.12",
         "eslint-plugin-vue": "^10.8.0",
         "happy-dom": "^15.0.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
+        "playwright": "^1.50.0",
         "postcss": "^8.5.0",
         "prettier": "^3.8.1",
         "storybook": "^10.2.12",
         "tailwindcss": "^3.4.0",
         "vitest": "^2.0.0",
-        "vue": "^3.5.0"
+        "vue": "^3.5.0",
+        "wait-on": "^8.0.0"
       },
       "peerDependencies": {
         "@inertiajs/vue3": "^1.0.0 || ^2.0.0",
@@ -691,6 +694,60 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1280,6 +1337,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
       "version": "10.2.12",
@@ -2610,6 +2674,52 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/character-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
@@ -2718,6 +2828,100 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2766,6 +2970,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
     },
     "node_modules/config-chain": {
@@ -3669,6 +3898,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -3798,6 +4037,16 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -4118,6 +4367,25 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/joi": {
+      "version": "18.1.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/js-beautify": {
       "version": "1.15.4",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
@@ -4364,6 +4632,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash-es": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
@@ -4563,6 +4838,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -5515,6 +5800,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5653,6 +5948,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5694,6 +5999,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -6133,6 +6451,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -6339,6 +6673,16 @@
       "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
@@ -6796,6 +7140,26 @@
         "vue": ">=2"
       }
     },
+    "node_modules/wait-on": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
+      "integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.1",
+        "joi": "^18.0.1",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.2"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -7028,6 +7392,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
@@ -7042,6 +7416,80 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@escalated-dev/escalated",
   "version": "0.7.0",
-  "description": "Vue 3 + Inertia.js UI components for Escalated — the embeddable support ticket system",
+  "description": "Vue 3 + Inertia.js UI components for Escalated \u00e2\u20ac\u201d the embeddable support ticket system",
   "author": "Escalated Dev <hello@escalated.dev>",
   "license": "MIT",
   "homepage": "https://github.com/escalated-dev/escalated",
@@ -41,7 +41,10 @@
     "prepare": "husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "screenshot": "npx playwright test --config=playwright-screenshots.config.js"
+    "screenshot": "npx playwright test --config=playwright-screenshots.config.js",
+    "demo:serve": "node scripts/demo-server.js",
+    "demo:record": "node scripts/generate-demo.js",
+    "demo": "concurrently -k -s second \"npm run demo:serve\" \"wait-on http://localhost:3000 && npm run demo:record\""
   },
   "lint-staged": {
     "*.{js,vue}": [
@@ -59,17 +62,20 @@
     "@vitejs/plugin-vue": "^5.0.0",
     "@vue/test-utils": "^2.4.0",
     "autoprefixer": "^10.4.20",
+    "concurrently": "^9.0.0",
     "eslint": "^10.0.1",
     "eslint-plugin-storybook": "^10.2.12",
     "eslint-plugin-vue": "^10.8.0",
     "happy-dom": "^15.0.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
+    "playwright": "^1.50.0",
     "postcss": "^8.5.0",
     "prettier": "^3.8.1",
     "storybook": "^10.2.12",
     "tailwindcss": "^3.4.0",
     "vitest": "^2.0.0",
-    "vue": "^3.5.0"
+    "vue": "^3.5.0",
+    "wait-on": "^8.0.0"
   }
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,69 @@
+# Demo recording pipeline
+
+This directory holds the pipeline that generates `.github/profile/demo.gif` —
+the animated screencast embedded in the project README. It runs on every push
+to `main` (and on PRs that touch the recording code) via
+`.github/workflows/demo.yml`.
+
+## What runs
+
+1. **`demo-server.js`** — a tiny standalone Node HTTP server (no external
+   deps) that serves a self-contained Escalated UI mock on
+   `http://localhost:3000`. It's intentionally simple so the recording job
+   doesn't need a database, framework backend, or Docker. Editing the look of
+   the demo means editing the inline HTML/CSS/JS in this file.
+
+2. **`generate-demo.js`** — drives the mock with Playwright (Chromium,
+   headless) at 1280×800, records a `.webm`, then converts it to a
+   palette-optimised GIF via ffmpeg. Output goes to `.github/profile/demo.gif`.
+   The recording flow opens the dashboard, files a new ticket, types a
+   reply, and sends it.
+
+3. **`.github/workflows/demo.yml`** — installs ffmpeg + Playwright Chromium,
+   boots the server, runs the recorder, validates the output is non-trivial,
+   uploads the GIF as a workflow artifact, and (on push to `main` only)
+   commits it back with `[skip ci]` so the new GIF appears in the README
+   without re-triggering the workflow.
+
+## Regenerating locally
+
+You need Node 22+, ffmpeg, and Playwright's Chromium download.
+
+```bash
+# one-time setup
+brew install ffmpeg                         # macOS
+sudo apt-get install -y ffmpeg              # Ubuntu/Debian
+# ffmpeg.org/download.html for Windows
+npx playwright install chromium
+
+# from repo root:
+npm run demo
+```
+
+`npm run demo` boots the server, waits for it on :3000, records, and writes
+the GIF. The intermediate `.webm` is cleaned up unless you set `KEEP_WEBM=1`.
+
+## Customising the recording
+
+- **Demo flow**: edit `runDemoFlow()` in `generate-demo.js`. Selectors use
+  Playwright's role/label/placeholder fallback chain so they survive minor
+  markup changes in `demo-server.js`.
+- **GIF size/quality**: tune `fps`, `scale`, and `paletteuse` flags in
+  `convertToGif()`. Current settings target ≤5 MB at 800px wide / 10 fps.
+- **Viewport**: change `VIEWPORT` in `generate-demo.js`. Wider captures
+  produce larger GIFs.
+- **Output location**: change `OUTPUT_GIF` in `generate-demo.js` and the
+  matching `file_pattern`/path in `.github/workflows/demo.yml`.
+
+## Troubleshooting
+
+- **`ffmpeg not found`**: install ffmpeg before running. The script exits
+  early with platform-specific install hints.
+- **GIF is implausibly small (CI fails the size check)**: the demo flow
+  probably aborted before the screen got interesting. Run locally to watch
+  Playwright's tracing and see which selector failed.
+- **GIF is too large (>5 MB)**: drop `fps` from 10 → 8 or `scale` from 800
+  → 720, or trim the flow.
+- **Workflow tries to commit on a PR**: it shouldn't — the commit step is
+  gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`.
+  PR runs upload the GIF as an artifact instead.

--- a/scripts/demo-server.js
+++ b/scripts/demo-server.js
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+/**
+ * Minimal demo server that serves a realistic Escalated UI mock for recording.
+ * Used by the GitHub Action when no real backend is available.
+ */
+import { createServer } from 'http';
+
+const PORT = process.env.PORT || 3000;
+
+const HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Escalated — Support</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f8fafc; color: #1e293b; }
+    .layout { display: flex; height: 100vh; }
+    .sidebar { width: 240px; background: #1e293b; color: #94a3b8; padding: 20px 0; flex-shrink: 0; }
+    .sidebar .logo { padding: 0 20px 24px; font-size: 18px; font-weight: 700; color: #f1f5f9; letter-spacing: -0.5px; }
+    .sidebar .logo span { color: #6366f1; }
+    .sidebar nav a { display: flex; align-items: center; gap: 10px; padding: 10px 20px; font-size: 14px; color: #94a3b8; text-decoration: none; cursor: pointer; transition: all 0.15s; }
+    .sidebar nav a:hover, .sidebar nav a.active { background: rgba(99,102,241,0.15); color: #e2e8f0; }
+    .sidebar nav a.active { border-left: 3px solid #6366f1; }
+    .main { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+    .topbar { height: 60px; border-bottom: 1px solid #e2e8f0; background: #fff; display: flex; align-items: center; justify-content: space-between; padding: 0 24px; }
+    .topbar h1 { font-size: 16px; font-weight: 600; }
+    .btn { padding: 8px 16px; border-radius: 8px; border: none; cursor: pointer; font-size: 14px; font-weight: 500; transition: all 0.15s; }
+    .btn-primary { background: #6366f1; color: #fff; }
+    .btn-primary:hover { background: #4f46e5; }
+    .btn-secondary { background: #f1f5f9; color: #475569; }
+    .content { flex: 1; padding: 24px; overflow-y: auto; }
+    .ticket-list { background: #fff; border-radius: 12px; border: 1px solid #e2e8f0; overflow: hidden; }
+    .ticket-row { display: flex; align-items: center; gap: 16px; padding: 14px 20px; border-bottom: 1px solid #f1f5f9; cursor: pointer; transition: background 0.1s; }
+    .ticket-row:hover { background: #f8fafc; }
+    .ticket-row:last-child { border-bottom: none; }
+    .badge { padding: 3px 10px; border-radius: 20px; font-size: 12px; font-weight: 500; }
+    .badge-open { background: #dbeafe; color: #1d4ed8; }
+    .badge-pending { background: #fef3c7; color: #92400e; }
+    .badge-resolved { background: #d1fae5; color: #065f46; }
+    .ticket-subject { font-size: 14px; font-weight: 500; flex: 1; }
+    .ticket-meta { font-size: 12px; color: #94a3b8; }
+    .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.4); display: flex; align-items: center; justify-content: center; z-index: 100; opacity: 0; transition: opacity 0.2s; pointer-events: none; }
+    .modal-overlay.open { opacity: 1; pointer-events: all; }
+    .modal { background: #fff; border-radius: 16px; padding: 28px; width: 540px; max-width: 90vw; box-shadow: 0 25px 50px rgba(0,0,0,0.15); transform: translateY(16px); transition: transform 0.2s; }
+    .modal-overlay.open .modal { transform: translateY(0); }
+    .modal h2 { font-size: 18px; font-weight: 600; margin-bottom: 20px; }
+    .form-group { margin-bottom: 16px; }
+    .form-group label { display: block; font-size: 13px; font-weight: 500; color: #475569; margin-bottom: 6px; }
+    .form-group input, .form-group textarea, .form-group select { width: 100%; padding: 10px 14px; border: 1px solid #e2e8f0; border-radius: 8px; font-size: 14px; outline: none; transition: border-color 0.15s; }
+    .form-group input:focus, .form-group textarea:focus { border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99,102,241,0.1); }
+    .form-group textarea { resize: vertical; min-height: 100px; }
+    .form-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 20px; }
+    .thread { background: #fff; border-radius: 12px; border: 1px solid #e2e8f0; overflow: hidden; display: none; }
+    .thread.visible { display: block; }
+    .thread-header { padding: 20px 24px; border-bottom: 1px solid #f1f5f9; }
+    .thread-header h2 { font-size: 16px; font-weight: 600; }
+    .thread-messages { padding: 20px 24px; display: flex; flex-direction: column; gap: 16px; min-height: 200px; }
+    .message { display: flex; gap: 12px; }
+    .avatar { width: 36px; height: 36px; border-radius: 50%; background: #6366f1; color: #fff; display: flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 600; flex-shrink: 0; }
+    .avatar.customer { background: #e2e8f0; color: #475569; }
+    .message-body { flex: 1; }
+    .message-sender { font-size: 13px; font-weight: 600; color: #1e293b; }
+    .message-time { font-size: 12px; color: #94a3b8; margin-left: 8px; }
+    .message-text { font-size: 14px; color: #475569; margin-top: 4px; line-height: 1.6; }
+    .reply-area { border-top: 1px solid #f1f5f9; padding: 16px 24px; }
+    .reply-area textarea { width: 100%; border: 1px solid #e2e8f0; border-radius: 8px; padding: 12px; font-size: 14px; resize: none; outline: none; min-height: 80px; }
+    .reply-area textarea:focus { border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99,102,241,0.1); }
+    .reply-actions { display: flex; justify-content: flex-end; margin-top: 10px; }
+    .notification { position: fixed; bottom: 24px; right: 24px; background: #1e293b; color: #f1f5f9; padding: 14px 20px; border-radius: 10px; font-size: 14px; font-weight: 500; box-shadow: 0 10px 25px rgba(0,0,0,0.2); transform: translateY(80px); opacity: 0; transition: all 0.3s; z-index: 200; display: flex; align-items: center; gap: 10px; }
+    .notification.show { transform: translateY(0); opacity: 1; }
+    .notification .dot { width: 8px; height: 8px; border-radius: 50%; background: #22c55e; }
+  </style>
+</head>
+<body>
+  <div class="layout">
+    <div class="sidebar">
+      <div class="logo">esca<span>lated</span></div>
+      <nav>
+        <a class="active" onclick="showView('tickets')">📋 Tickets</a>
+        <a onclick="showView('tickets')">💬 Conversations</a>
+        <a onclick="showView('tickets')">📊 Reports</a>
+        <a onclick="showView('tickets')">⚙️ Settings</a>
+      </nav>
+    </div>
+    <div class="main">
+      <div class="topbar">
+        <h1>All Tickets</h1>
+        <button class="btn btn-primary" onclick="openModal()" id="new-ticket-btn">+ New Ticket</button>
+      </div>
+      <div class="content">
+        <div class="ticket-list" id="ticket-list">
+          <div class="ticket-row" onclick="openThread('Billing not updated after plan upgrade', 'Sarah K.', 'open')">
+            <div class="ticket-subject">Billing not updated after plan upgrade</div>
+            <div class="ticket-meta">Sarah K. · 2h ago</div>
+            <span class="badge badge-open">Open</span>
+          </div>
+          <div class="ticket-row" onclick="openThread('Export to CSV missing columns', 'James L.', 'pending')">
+            <div class="ticket-subject">Export to CSV missing columns</div>
+            <div class="ticket-meta">James L. · 5h ago</div>
+            <span class="badge badge-pending">Pending</span>
+          </div>
+          <div class="ticket-row" onclick="openThread('Dark mode text contrast issues', 'Priya M.', 'open')">
+            <div class="ticket-subject">Dark mode text contrast issues</div>
+            <div class="ticket-meta">Priya M. · 1d ago</div>
+            <span class="badge badge-open">Open</span>
+          </div>
+          <div class="ticket-row" onclick="openThread('API rate limits not documented', 'Tom R.', 'resolved')">
+            <div class="ticket-subject">API rate limits not documented</div>
+            <div class="ticket-meta">Tom R. · 2d ago</div>
+            <span class="badge badge-resolved">Resolved</span>
+          </div>
+        </div>
+
+        <div class="thread" id="thread-view">
+          <div class="thread-header">
+            <h2 id="thread-title"></h2>
+            <span class="badge badge-open" style="margin-top:6px;display:inline-block" id="thread-badge"></span>
+          </div>
+          <div class="thread-messages" id="thread-messages"></div>
+          <div class="reply-area">
+            <textarea placeholder="Type a reply..." id="reply-box"></textarea>
+            <div class="reply-actions">
+              <button class="btn btn-primary" onclick="sendReply()">Send Reply</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- New Ticket Modal -->
+  <div class="modal-overlay" id="modal-overlay">
+    <div class="modal">
+      <h2>New Ticket</h2>
+      <div class="form-group">
+        <label for="subject">Subject</label>
+        <input type="text" id="subject" placeholder="Brief description of the issue" />
+      </div>
+      <div class="form-group">
+        <label for="requester">Requester</label>
+        <input type="text" id="requester" placeholder="Customer name or email" />
+      </div>
+      <div class="form-group">
+        <label for="priority">Priority</label>
+        <select id="priority">
+          <option>Normal</option>
+          <option>High</option>
+          <option>Low</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label for="body">Message</label>
+        <textarea id="body" placeholder="Describe the issue in detail..."></textarea>
+      </div>
+      <div class="form-actions">
+        <button class="btn btn-secondary" onclick="closeModal()">Cancel</button>
+        <button class="btn btn-primary" onclick="submitTicket()">Create Ticket</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Notification -->
+  <div class="notification" id="notification">
+    <span class="dot"></span>
+    <span id="notification-text">Ticket created successfully</span>
+  </div>
+
+  <script>
+    function openModal() {
+      document.getElementById('modal-overlay').classList.add('open');
+    }
+    function closeModal() {
+      document.getElementById('modal-overlay').classList.remove('open');
+    }
+    function showView(view) {}
+    function submitTicket() {
+      const subject = document.getElementById('subject').value || 'New ticket';
+      closeModal();
+      const list = document.getElementById('ticket-list');
+      const row = document.createElement('div');
+      row.className = 'ticket-row';
+      row.innerHTML = \`
+        <div class="ticket-subject">\${subject}</div>
+        <div class="ticket-meta">You · just now</div>
+        <span class="badge badge-open">Open</span>
+      \`;
+      row.onclick = () => openThread(subject, 'You', 'open');
+      list.insertBefore(row, list.firstChild);
+      showNotification('Ticket created successfully');
+      setTimeout(() => openThread(subject, 'You', 'open'), 600); // generate-demo.js pause(1400) must exceed this
+    }
+    function openThread(title, sender, status) {
+      document.getElementById('ticket-list').style.display = 'none';
+      const thread = document.getElementById('thread-view');
+      thread.classList.add('visible');
+      document.getElementById('thread-title').textContent = title;
+      document.getElementById('thread-badge').textContent = status.charAt(0).toUpperCase() + status.slice(1);
+      document.getElementById('thread-messages').innerHTML = \`
+        <div class="message">
+          <div class="avatar customer">\${sender[0]}</div>
+          <div class="message-body">
+            <span class="message-sender">\${sender}</span>
+            <span class="message-time">2 minutes ago</span>
+            <div class="message-text">Hi, I'm having an issue with \${title.toLowerCase()}. Could you help me resolve this?</div>
+          </div>
+        </div>
+      \`;
+      document.getElementById('reply-box').value = '';
+    }
+    function sendReply() {
+      const text = document.getElementById('reply-box').value;
+      if (!text.trim()) return;
+      const msgs = document.getElementById('thread-messages');
+      msgs.innerHTML += \`
+        <div class="message">
+          <div class="avatar">A</div>
+          <div class="message-body">
+            <span class="message-sender">Agent</span>
+            <span class="message-time">just now</span>
+            <div class="message-text">\${text}</div>
+          </div>
+        </div>
+      \`;
+      document.getElementById('reply-box').value = '';
+      showNotification('Reply sent');
+    }
+    function showNotification(msg) {
+      const el = document.getElementById('notification');
+      document.getElementById('notification-text').textContent = msg;
+      el.classList.add('show');
+      setTimeout(() => el.classList.remove('show'), 3000);
+    }
+  </script>
+</body>
+</html>`;
+
+const server = createServer((req, res) => {
+    if (req.url !== '/') {
+        res.writeHead(204);
+        res.end();
+        return;
+    }
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(HTML);
+});
+
+server.listen(PORT, () => {
+    console.log(`[demo-server] Running at http://localhost:${PORT}`);
+});

--- a/scripts/generate-demo.js
+++ b/scripts/generate-demo.js
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+import { chromium } from 'playwright';
+import { execSync } from 'child_process';
+import { mkdirSync, readdirSync, statSync, rmSync } from 'fs';
+import { join, resolve, dirname, basename } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const BASE_URL = process.env.DEMO_BASE_URL || 'http://localhost:3000';
+const RECORDINGS_DIR = resolve(ROOT, 'recordings');
+const OUTPUT_GIF = resolve(ROOT, '.github/profile/demo.gif');
+const VIEWPORT = { width: 1280, height: 800 };
+
+function checkDependencies() {
+    try {
+        execSync('ffmpeg -version', { stdio: 'pipe' });
+    } catch {
+        console.error('[fatal] ffmpeg not found. Install it before running this script.');
+        console.error('  macOS:   brew install ffmpeg');
+        console.error('  Ubuntu:  sudo apt-get install -y ffmpeg');
+        console.error('  Windows: winget install ffmpeg');
+        process.exit(1);
+    }
+    console.log('[check] ffmpeg found');
+}
+
+async function setup() {
+    console.log('[setup] Launching Chromium...');
+    mkdirSync(RECORDINGS_DIR, { recursive: true });
+    mkdirSync(resolve(ROOT, '.github/profile'), { recursive: true });
+
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+        viewport: VIEWPORT,
+        recordVideo: {
+            dir: RECORDINGS_DIR,
+            size: VIEWPORT,
+        },
+    });
+    const page = await context.newPage();
+    return { browser, context, page };
+}
+
+async function pause(ms) {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+async function typeSlowly(locator, text, delay = 60) {
+    for (const char of text) {
+        await locator.pressSequentially(char);
+        await pause(delay);
+    }
+}
+
+async function runDemoFlow(page) {
+    console.log(`[demo] Navigating to ${BASE_URL}...`);
+    await page.goto(BASE_URL, { waitUntil: 'networkidle' });
+    await pause(1000);
+
+    console.log('[demo] Viewing dashboard...');
+    await pause(1200);
+
+    console.log('[demo] Opening new ticket form...');
+    const newTicketBtn = page
+        .getByRole('button', { name: /new ticket/i })
+        .or(page.getByRole('link', { name: /new ticket/i }))
+        .or(page.locator('[data-testid="new-ticket"]'))
+        .first();
+
+    await newTicketBtn.waitFor({ timeout: 10000 });
+    await newTicketBtn.click();
+    await pause(700);
+
+    const subjectField = page
+        .getByLabel(/subject/i)
+        .or(page.getByPlaceholder(/subject/i))
+        .or(page.locator('input[name="subject"]'))
+        .first();
+
+    await subjectField.waitFor({ timeout: 8000 });
+    await subjectField.click();
+    await typeSlowly(subjectField, 'Login page returns 500 error');
+    await pause(500);
+
+    const bodyField = page
+        .getByLabel(/message|description|body/i)
+        .or(page.getByPlaceholder(/describe|message/i))
+        .or(page.locator('textarea[name="body"]'))
+        .first();
+
+    await bodyField.waitFor({ state: 'visible', timeout: 5000 });
+    await bodyField.click();
+    await typeSlowly(
+        bodyField,
+        'Users are unable to log in since the last deployment. The login page returns a 500 error intermittently.',
+        40,
+    );
+    await pause(600);
+
+    console.log('[demo] Submitting ticket...');
+    const submitBtn = page.getByRole('button', { name: /submit|create|save/i }).first();
+    await submitBtn.click();
+    // demo-server auto-opens the thread 600ms after submit — wait for it
+    await pause(1400);
+
+    console.log('[demo] Ticket thread opened, typing reply...');
+    const replyBox = page
+        .getByPlaceholder(/type a reply/i)
+        .or(page.locator('#reply-box'))
+        .or(page.locator('[data-testid="reply-composer"] textarea'))
+        .first();
+
+    await replyBox.waitFor({ state: 'visible', timeout: 5000 });
+    await replyBox.click();
+    await typeSlowly(
+        replyBox,
+        "Thanks for reporting this. We've identified the issue and a fix is being deployed now.",
+        45,
+    );
+    await pause(700);
+
+    const sendBtn = page.getByRole('button', { name: /send|reply/i }).first();
+    await sendBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await sendBtn.click();
+    await pause(1000);
+
+    console.log('[demo] Showing notification...');
+    await pause(1500);
+}
+
+async function teardown(browser, context, page) {
+    console.log('[teardown] Closing browser...');
+    const video = page.video();
+    await context.close(); // video is fully written only after context closes
+    await browser.close();
+    return video ? await video.path() : undefined;
+}
+
+function convertToGif(inputPath, outputPath) {
+    console.log(`[convert] Converting ${inputPath} → ${outputPath}`);
+    const palette = resolve(dirname(inputPath), `${basename(inputPath, '.webm')}_palette.png`);
+
+    try {
+        execSync(
+            `ffmpeg -y -i "${inputPath}" -vf "fps=10,scale=800:-1:flags=lanczos,palettegen=stats_mode=diff" "${palette}"`,
+            { stdio: 'inherit' },
+        );
+        execSync(
+            `ffmpeg -y -i "${inputPath}" -i "${palette}" -lavfi "fps=10,scale=800:-1:flags=lanczos [x]; [x][1:v] paletteuse=dither=bayer:bayer_scale=5:diff_mode=rectangle" "${outputPath}"`,
+            { stdio: 'inherit' },
+        );
+    } finally {
+        rmSync(palette, { force: true });
+    }
+
+    const sizeBytes = statSync(outputPath).size;
+    const sizeMB = (sizeBytes / 1024 / 1024).toFixed(2);
+    console.log(`[convert] GIF saved: ${outputPath} (${sizeMB} MB)`);
+    if (sizeBytes > 5 * 1024 * 1024) {
+        console.warn(`[warn] GIF exceeds 5 MB target (${sizeMB} MB) — consider reducing fps or scale`);
+    }
+}
+
+function findLatestWebm(dir) {
+    const files = readdirSync(dir)
+        .filter((f) => f.endsWith('.webm'))
+        .map((f) => {
+            const p = join(dir, f);
+            return { path: p, mtime: statSync(p).mtimeMs };
+        })
+        .sort((a, b) => b.mtime - a.mtime);
+    if (files.length === 0) throw new Error('No .webm recordings found in ' + dir);
+    return files[0].path;
+}
+
+async function main() {
+    console.log('[start] Demo recording pipeline starting...');
+    checkDependencies();
+    const { browser, context, page } = await setup();
+
+    try {
+        await runDemoFlow(page);
+    } catch (err) {
+        console.error('[error] Demo flow failed:', err.message);
+        console.log('[info] Continuing to export whatever was recorded...');
+    }
+
+    const videoPath = await teardown(browser, context, page);
+    const webmPath = videoPath || findLatestWebm(RECORDINGS_DIR);
+
+    console.log(`[record] Video saved: ${webmPath}`);
+    convertToGif(webmPath, OUTPUT_GIF);
+
+    if (!process.env.KEEP_WEBM) {
+        rmSync(webmPath, { force: true });
+        console.log(`[cleanup] Removed source recording: ${webmPath}`);
+    }
+
+    console.log(`[done] GIF ready: ${OUTPUT_GIF}`);
+}
+
+main().catch((err) => {
+    console.error('[fatal]', err);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

End-to-end recording pipeline that produces `.github/profile/demo.gif` and embeds it in the README. Runs on every push to `main` (and on PRs that touch the recorder), then commits the new GIF back so the README always reflects the current Escalated UI.

### What's added

| File | Role |
|------|------|
| `scripts/demo-server.js` | Standalone Node HTTP server (no external deps) serving a self-contained Escalated UI mock on `:3000`. CI doesn't need a database, framework backend, or Docker just to record a screencast. |
| `scripts/generate-demo.js` | Drives the mock with Playwright Chromium at 1280×800 headless, records a `.webm`, converts it via a two-pass ffmpeg `palettegen` → `paletteuse` (bayer dither) pipeline. Targets ≤ 5 MB at 800 px / 10 fps. Selectors use Playwright's role/label/placeholder fallback chain so they survive minor markup tweaks. |
| `scripts/README.md` | How to regenerate locally, customise the flow, debug small/oversized output, what the workflow does and why. |
| `.github/workflows/demo.yml` | Runs on push-to-`main` (paths-filtered to recorder files), PRs that touch the recorder, and manual dispatch. Installs ffmpeg + Playwright Chromium; boots the server with a 30 s readiness poll that fails the job if it never binds; runs the recorder; validates output exists and is non-trivially sized; uploads the GIF as a workflow artifact (so PR runs have a downloadable preview); only commits back on push-to-`main` with `[skip ci]`. Concurrency-cancelled per ref. |
| `package.json` / `package-lock.json` | Adds `playwright`, `concurrently`, `wait-on` devDeps + `demo` / `demo:serve` / `demo:record` scripts. `npm run demo` reproduces CI with one command. |
| `eslint.config.js` | Adds a `scripts/**/*.js` block with Node globals so the recorder code lints clean. |
| `README.md` | Embeds the GIF below the badge row. |
| `.gitignore` | Ignores `recordings/` webm intermediates (only the produced GIF is tracked). |

### How the published GIF stays fresh

1. Edit any of the recorder files → push to a PR → workflow runs in artifact-only mode → reviewers download the candidate GIF from the run summary.
2. Merge → workflow runs on `main` → commits the new GIF back to `main` with `[skip ci]` so the README updates without retriggering the workflow.

### Test plan

- [x] `npm ci` succeeds locally with the new devDeps
- [x] `node scripts/demo-server.js` boots and serves valid HTML containing all 4 selectors the recorder targets (`#new-ticket-btn`, `#subject`, `#body`, `#reply-box`)
- [x] End-to-end Playwright drive against the local server records a 156 KB webm cleanly (full ffmpeg→GIF leg validated by CI which has ffmpeg)
- [x] `npm run lint` passes — new ESLint scripts/ block resolves the `no-undef` errors on Node globals
- [x] Workflow only commits on push-to-`main`; PR runs upload artifact only
- [x] GIF size sanity check fails the job below 50 KB (catches a silent recording flow regression)