### PR TITLE
fix: commit demo GIF on workflow_dispatch

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -8,6 +8,7 @@ on:
       - 'scripts/generate-demo.js'
       - '.github/workflows/demo.yml'
   pull_request:
+    branches: [main]
     paths:
       - 'scripts/demo-server.js'
       - 'scripts/generate-demo.js'

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Only commit on push-to-main runs so PR runs don't try to push.
       - name: Commit updated GIF
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: update demo GIF [skip ci]'


### PR DESCRIPTION
The commit step was gated to `push` events only, so manually triggering via `workflow_dispatch` would generate the GIF but never commit it back. Changed condition to `github.ref == 'refs/heads/main' && github.event_name != 'pull_request'` so push and workflow_dispatch both commit.