### PR TITLE
feat(demo): record against real escalated-laravel Docker app

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -8,6 +8,7 @@ on:
       - 'scripts/generate-demo.js'
       - '.github/workflows/demo.yml'
   pull_request:
+    branches: [main]
     paths:
       - 'scripts/demo-server.js'
       - 'scripts/generate-demo.js'

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Only commit on push-to-main runs so PR runs don't try to push.
       - name: Commit updated GIF
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'chore: update demo GIF [skip ci]'

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -4,13 +4,11 @@ on:
   push:
     branches: [main]
     paths:
-      - 'scripts/demo-server.js'
       - 'scripts/generate-demo.js'
       - '.github/workflows/demo.yml'
   pull_request:
     branches: [main]
     paths:
-      - 'scripts/demo-server.js'
       - 'scripts/generate-demo.js'
       - '.github/workflows/demo.yml'
   workflow_dispatch:
@@ -27,13 +25,20 @@ concurrency:
 jobs:
   generate-demo:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
-      - name: Checkout code
+      - name: Checkout escalated (this repo)
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout escalated-laravel
+        uses: actions/checkout@v4
+        with:
+          repository: escalated-dev/escalated-laravel
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: escalated-laravel
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -52,34 +57,29 @@ jobs:
       - name: Install Playwright Chromium
         run: node_modules/.bin/playwright install chromium --with-deps
 
-      - name: Start demo server
+      - name: Build and start demo app
         run: |
-          node scripts/demo-server.js &
-          echo "APP_PID=$!" >> "$GITHUB_ENV"
-          # Poll for readiness (max 30s); fail loudly if the server never binds.
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000 -o /dev/null; then
-              echo "[ready] Demo server up after ${i}s"
+          docker compose -f escalated-laravel/docker/compose.yml up -d --build
+          echo "[boot] Waiting for app to be ready (max 120s)..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8000/demo -o /dev/null 2>/dev/null; then
+              echo "[ready] App up after $((i * 2))s"
               exit 0
             fi
-            sleep 1
+            sleep 2
           done
-          echo "::error::Demo server did not become ready within 30s"
+          echo "::error::App did not become ready within 120s"
+          docker compose -f escalated-laravel/docker/compose.yml logs
           exit 1
-        env:
-          PORT: 3000
 
       - name: Generate demo GIF
         run: node scripts/generate-demo.js
         env:
-          DEMO_BASE_URL: http://localhost:3000
+          DEMO_BASE_URL: http://localhost:8000
 
-      - name: Stop demo server
+      - name: Stop demo app
         if: always()
-        run: |
-          if [ -n "${APP_PID:-}" ]; then
-            kill "$APP_PID" 2>/dev/null || true
-          fi
+        run: docker compose -f escalated-laravel/docker/compose.yml down -v
 
       - name: Verify GIF was generated
         run: |

--- a/scripts/generate-demo.js
+++ b/scripts/generate-demo.js
@@ -6,7 +6,7 @@ import { join, resolve, dirname, basename } from 'path';
 import { fileURLToPath } from 'url';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-const BASE_URL = process.env.DEMO_BASE_URL || 'http://localhost:3000';
+const BASE_URL = process.env.DEMO_BASE_URL || 'http://localhost:8000';
 const RECORDINGS_DIR = resolve(ROOT, 'recordings');
 const OUTPUT_GIF = resolve(ROOT, '.github/profile/demo.gif');
 const VIEWPORT = { width: 1280, height: 800 };
@@ -53,79 +53,44 @@ async function typeSlowly(locator, text, delay = 60) {
 }
 
 async function runDemoFlow(page) {
-    console.log(`[demo] Navigating to ${BASE_URL}...`);
-    await page.goto(BASE_URL, { waitUntil: 'networkidle' });
+    console.log(`[demo] Loading demo picker at ${BASE_URL}/demo ...`);
+    await page.goto(`${BASE_URL}/demo`, { waitUntil: 'networkidle' });
     await pause(1000);
 
-    console.log('[demo] Viewing dashboard...');
+    console.log('[demo] Logging in as Alice Admin...');
+    const aliceBtn = page.locator('button.user').filter({ hasText: 'Alice Admin' });
+    await aliceBtn.waitFor({ state: 'visible', timeout: 15000 });
+    await aliceBtn.click();
+
+    console.log('[demo] Waiting for ticket list...');
+    await page.waitForURL('**/admin/tickets**', { timeout: 20000 });
+    await page.waitForLoadState('networkidle');
+    await pause(1500);
+
+    console.log('[demo] Clicking into first ticket...');
+    // Reference column links are the first <a> in each table row
+    const firstTicketLink = page.locator('table tbody tr').first().locator('a').first();
+    await firstTicketLink.waitFor({ state: 'visible', timeout: 10000 });
+    await firstTicketLink.click();
+    await page.waitForLoadState('networkidle');
     await pause(1200);
 
-    console.log('[demo] Opening new ticket form...');
-    const newTicketBtn = page
-        .getByRole('button', { name: /new ticket/i })
-        .or(page.getByRole('link', { name: /new ticket/i }))
-        .or(page.locator('[data-testid="new-ticket"]'))
-        .first();
-
-    await newTicketBtn.waitFor({ timeout: 10000 });
-    await newTicketBtn.click();
-    await pause(700);
-
-    const subjectField = page
-        .getByLabel(/subject/i)
-        .or(page.getByPlaceholder(/subject/i))
-        .or(page.locator('input[name="subject"]'))
-        .first();
-
-    await subjectField.waitFor({ timeout: 8000 });
-    await subjectField.click();
-    await typeSlowly(subjectField, 'Login page returns 500 error');
-    await pause(500);
-
-    const bodyField = page
-        .getByLabel(/message|description|body/i)
-        .or(page.getByPlaceholder(/describe|message/i))
-        .or(page.locator('textarea[name="body"]'))
-        .first();
-
-    await bodyField.waitFor({ state: 'visible', timeout: 5000 });
-    await bodyField.click();
+    console.log('[demo] Typing reply...');
+    const replyTextarea = page.locator('textarea[aria-label="Reply message"]').first();
+    await replyTextarea.waitFor({ state: 'visible', timeout: 10000 });
+    await replyTextarea.click();
     await typeSlowly(
-        bodyField,
-        'Users are unable to log in since the last deployment. The login page returns a 500 error intermittently.',
-        40,
-    );
-    await pause(600);
-
-    console.log('[demo] Submitting ticket...');
-    const submitBtn = page.getByRole('button', { name: /submit|create|save/i }).first();
-    await submitBtn.click();
-    // demo-server auto-opens the thread 600ms after submit — wait for it
-    await pause(1400);
-
-    console.log('[demo] Ticket thread opened, typing reply...');
-    const replyBox = page
-        .getByPlaceholder(/type a reply/i)
-        .or(page.locator('#reply-box'))
-        .or(page.locator('[data-testid="reply-composer"] textarea'))
-        .first();
-
-    await replyBox.waitFor({ state: 'visible', timeout: 5000 });
-    await replyBox.click();
-    await typeSlowly(
-        replyBox,
-        "Thanks for reporting this. We've identified the issue and a fix is being deployed now.",
+        replyTextarea,
+        "Thanks for reaching out! We've identified the issue and a fix is being deployed. I'll follow up once it's live.",
         45,
     );
-    await pause(700);
+    await pause(800);
 
-    const sendBtn = page.getByRole('button', { name: /send|reply/i }).first();
+    console.log('[demo] Sending reply...');
+    const sendBtn = page.getByRole('button', { name: /send reply/i }).first();
     await sendBtn.waitFor({ state: 'visible', timeout: 5000 });
     await sendBtn.click();
-    await pause(1000);
-
-    console.log('[demo] Showing notification...');
-    await pause(1500);
+    await pause(2000);
 }
 
 async function teardown(browser, context, page) {


### PR DESCRIPTION
## Summary

- Replaces the fake `demo-server.js` HTML mock with the real `escalated-laravel` Docker Compose stack (PHP 8.3, PostgreSQL 16, DemoSeeder with 55 realistic tickets)
- Workflow checks out `escalated-dev/escalated-laravel`, builds the image, starts all services, and polls `/demo` until the app is ready (migrations + seeding complete)
- `generate-demo.js` updated to navigate the real Escalated UI: demo picker → login as Alice Admin → ticket list → open first ticket → type and send a reply using Inertia selectors (`aria-label="Reply message"`, `Send Reply` button)
- Timeout bumped to 25 min to accommodate Docker image build on first run

## Test plan

- [ ] PR CI: check the uploaded GIF artifact shows the real dark-theme Escalated UI (not the mock)
- [ ] Merge to main: confirm GIF is committed to `.github/profile/demo.gif` and visible in the README