### PR TITLE
fix(deps): accept @inertiajs/vue3 v3 in peerDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@escalated-dev/escalated` will be documented in this fil
 
 ## [Unreleased]
 
+### Changed
+- `peerDependencies."@inertiajs/vue3"` widened from `^1.0.0 || ^2.0.0` to `^1.0.0 || ^2.0.0 || ^3.0.0`. Host apps on `@inertiajs/vue3` 3.x no longer trip an `npm install` peer-dep conflict. We use only `Link`, `router`, `useForm`, and `usePage` from this package, all stable across the v1/v2/v3 line.
+
 ### Fixed
 - Widget's API endpoint path is now configurable via `data-widget-path` (on the script tag) / `widgetPath` option (on `createEscalated`). Default stays `/support/widget` for backward compatibility. Unblocks NestJS hosts where the base path isn't `/support`.
 - `useChat()` threads the resolved `widgetPath` through all six chat API endpoints; Agent `TicketShow`, `ActiveChatsPanel`, `ChatQueue` read `page.props.escalated?.prefix` to build the right path on the agent side.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "src"
   ],
   "peerDependencies": {
-    "@inertiajs/vue3": "^1.0.0 || ^2.0.0",
+    "@inertiajs/vue3": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "vue": "^3.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Host apps on `@inertiajs/vue3@3.x` were tripping an `npm install` peer-dep conflict because our `peerDependencies` was capped at `^1.0.0 || ^2.0.0`. Widen to also accept `^3.0.0`.

We import only `Link`, `router`, `useForm`, and `usePage` from `@inertiajs/vue3`, all stable across the v1 → v2 → v3 line.