### PR TITLE
chore(release): bump version to 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to `@escalated-dev/escalated` will be documented in this fil
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-04-28
+
 ### Changed
 - `peerDependencies."@inertiajs/vue3"` widened from `^1.0.0 || ^2.0.0` to `^1.0.0 || ^2.0.0 || ^3.0.0`. Host apps on `@inertiajs/vue3` 3.x no longer trip an `npm install` peer-dep conflict. We use only `Link`, `router`, `useForm`, and `usePage` from this package, all stable across the v1/v2/v3 line.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@escalated-dev/escalated",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Vue 3 + Inertia.js UI components for Escalated \u00e2\u20ac\u201d the embeddable support ticket system",
   "author": "Escalated Dev <hello@escalated.dev>",
   "license": "MIT",


### PR DESCRIPTION
Bumps `@escalated-dev/escalated` to v0.7.1 with the Inertia v3 peer-dep widen ([#39](https://github.com/escalated-dev/escalated/pull/39)) and the widget-path configurability fix ([#35](https://github.com/escalated-dev/escalated/pull/35)).

## Test plan
- [x] CHANGELOG entry rolls Unreleased into [0.7.1]
- [x] package.json version bumped 0.7.0 → 0.7.1