### PR TITLE
ci(screenshots): fix detached-HEAD push + skip rebuild when no visual changes

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -27,21 +27,57 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      # Storybook screenshots only need re-rendering when something
+      # visual actually changed — Vue components, Storybook config /
+      # global CSS, or the screenshot Playwright config itself. Skip
+      # the (~5 min) build + render + upload work otherwise. Always
+      # run on workflow_dispatch so manual reruns aren't blocked.
+      - name: Detect visual changes since previous tag
+        id: visual_diff
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "manual dispatch — running"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          PREV_TAG=$(git describe --abbrev=0 --tags HEAD^ 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            echo "no previous tag — running"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --quiet "$PREV_TAG" HEAD -- \
+                'src/**/*.vue' \
+                'src/**/*.css' \
+                '.storybook/**' \
+                'playwright-screenshots.config.js'; then
+            echo "no visual changes since $PREV_TAG — skipping"
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "visual changes detected since $PREV_TAG — running"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Setup Node.js
+        if: steps.visual_diff.outputs.should_run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22
 
       - name: Install dependencies
+        if: steps.visual_diff.outputs.should_run == 'true'
         run: npm install
 
       - name: Install Playwright Chromium
+        if: steps.visual_diff.outputs.should_run == 'true'
         run: npx playwright install chromium --with-deps
 
       - name: Build Storybook
+        if: steps.visual_diff.outputs.should_run == 'true'
         run: npx storybook build --output-dir storybook-static
 
       - name: Take screenshots
+        if: steps.visual_diff.outputs.should_run == 'true'
         run: |
           npx http-server storybook-static -p 6006 -s &
           sleep 3
@@ -50,14 +86,14 @@ jobs:
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && steps.visual_diff.outputs.should_run == 'true'
         with:
           name: component-screenshots
           path: screenshot-results/*.png
           retention-days: 30
 
       - name: Commit updated README screenshots
-        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        if: steps.visual_diff.outputs.should_run == 'true' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -16,8 +16,16 @@ jobs:
     name: Component Screenshots
 
     steps:
-      - name: Checkout code
+      # Tag-triggered runs default to a detached-HEAD checkout of the
+      # tagged commit, which makes the screenshot-update commit at the
+      # bottom of this job unpushable. Pin to main so we can commit +
+      # push back. The Storybook content is the same either way (main
+      # HEAD == tag commit when the tag is fresh).
+      - name: Checkout main
         uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -54,8 +62,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/assets/escalated_admin_1.png docs/assets/escalated_admin_2.png
-          git diff --cached --quiet && echo "No screenshot changes" || {
-            git commit -m "chore: update README screenshots from Storybook"
-            git push
-          }
+          if git diff --cached --quiet; then
+            echo "No screenshot changes"
+          else
+            git commit -m "chore: update README screenshots from Storybook [skip ci]"
+            git push origin HEAD:main
+          fi
 


### PR DESCRIPTION
## Two changes to `.github/workflows/screenshots.yml`

### 1. Fix detached-HEAD push on tag triggers

The workflow runs on `v*` tag pushes. `actions/checkout@v4` checks out the tagged commit (detached HEAD) on tag-triggered runs, so the auto-commit + `git push` at the bottom of the job fails:

```
[detached HEAD 7ed2b35] chore: update README screenshots from Storybook
fatal: You are not currently on a branch.
```

Observed on the v0.7.1 release tag run.

**Fix:**
- `actions/checkout@v4` with `ref: main` so the run has a branch to push to.
- `git push origin HEAD:main` explicit ref instead of bare `git push`.
- `if`/`else` guard around the diff check (the `&& ||` chain silently swallowed commit failures).
- `[skip ci]` on the auto-commit so the screenshot bump doesn't re-trigger the same workflow.

### 2. Skip the build entirely when no visual files changed

Storybook screenshots only need re-rendering when something visual actually changed. Diff between the current tag and the previous tag — short-circuit the ~5 minute Playwright + Storybook pipeline when the diff touches none of:

- `src/**/*.vue`
- `src/**/*.css`
- `.storybook/**`
- `playwright-screenshots.config.js`

`workflow_dispatch` always runs (manual reruns shouldn't be blocked).

Doc-only releases, dependency bumps, and `[skip ci]`-style commits no longer pay the screenshot tax.