### PR TITLE
feat(i18n): consume central translations from @escalated-dev/locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to `@escalated-dev/escalated` will be documented in this fil
 
 ## [Unreleased]
 
+### Added
+- feat: consume translations from `@escalated-dev/locale` as the canonical base source, with `src/locales/*.json` retained as local plugin overrides that win over central. Public `useI18n().t()` / `$t` API is unchanged.
+
 ## [0.7.1] - 2026-04-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@escalated-dev/escalated",
       "version": "0.7.1",
       "license": "MIT",
+      "dependencies": {
+        "@escalated-dev/locale": "github:escalated-dev/escalated-locale#v0.1.2"
+      },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@inertiajs/vue3": "^2.0.0",
@@ -526,6 +529,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@escalated-dev/locale": {
+      "version": "0.1.2",
+      "resolved": "git+ssh://git@github.com/escalated-dev/escalated-locale.git#db1afd52b378529eeb9ede81862d85192f580a5c",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "vue": "^3.3.0"
   },
   "dependencies": {
-    "@escalated-dev/locale": "^0.1.0"
+    "@escalated-dev/locale": "github:escalated-dev/escalated-locale#v0.1.2"
   },
   "scripts": {
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "@inertiajs/vue3": "^1.0.0 || ^2.0.0 || ^3.0.0",
     "vue": "^3.3.0"
   },
+  "dependencies": {
+    "@escalated-dev/locale": "^0.1.0"
+  },
   "scripts": {
     "test": "vitest run",
     "lint": "eslint src/ --max-warnings 0",

--- a/src/composables/useI18n.js
+++ b/src/composables/useI18n.js
@@ -1,5 +1,17 @@
 import { ref, computed } from 'vue';
-import locales from '../locales/index.js';
+import overrideLocales from '../locales/index.js';
+
+// Central translations published from escalated-dev/escalated-locale.
+// This is the BASE layer. Local src/locales/*.json files in this repo are
+// loaded as OVERRIDES and win over the central source for any matching key.
+//
+// Until @escalated-dev/locale v0.1.0 ships its consolidated strings, this
+// import resolves to a stub object with the same shape. Local overrides
+// (src/locales/) preserve the current behavior so components keep rendering
+// the strings they always rendered. After Codex finishes consolidating
+// translations into the central package, the local override files can be
+// trimmed (or deleted entirely) and the central source becomes authoritative.
+import centralLocales from '@escalated-dev/locale';
 
 const currentLocale = ref('en');
 const customMessages = ref({});
@@ -55,21 +67,31 @@ export function useI18n() {
     function t(key, replacements) {
         const lang = currentLocale.value;
 
-        // Try custom messages for current locale
+        // 1. Host-app supplied messages for the current locale (highest priority).
         const custom = resolve(customMessages.value[lang], key);
         if (typeof custom === 'string') return applyReplacements(custom, replacements);
 
-        // Try built-in messages for current locale
-        const msg = resolve(locales[lang], key);
-        if (typeof msg === 'string') return applyReplacements(msg, replacements);
+        // 2. Local plugin overrides for the current locale (src/locales/*.json).
+        //    These exist to let this repo win over the central source for any
+        //    string the plugin needs to phrase differently.
+        const override = resolve(overrideLocales[lang], key);
+        if (typeof override === 'string') return applyReplacements(override, replacements);
 
-        // Fallback to English
+        // 3. Central source for the current locale (@escalated-dev/locale).
+        //    This is the canonical base layer.
+        const central = resolve(centralLocales?.[lang], key);
+        if (typeof central === 'string') return applyReplacements(central, replacements);
+
+        // 4. English fallbacks, in the same priority order.
         if (lang !== 'en') {
             const customEn = resolve(customMessages.value.en, key);
             if (typeof customEn === 'string') return applyReplacements(customEn, replacements);
 
-            const fallback = resolve(locales.en, key);
-            if (typeof fallback === 'string') return applyReplacements(fallback, replacements);
+            const overrideEn = resolve(overrideLocales.en, key);
+            if (typeof overrideEn === 'string') return applyReplacements(overrideEn, replacements);
+
+            const centralEn = resolve(centralLocales?.en, key);
+            if (typeof centralEn === 'string') return applyReplacements(centralEn, replacements);
         }
 
         // Return raw key

--- a/src/locales/README.md
+++ b/src/locales/README.md
@@ -1,0 +1,13 @@
+# Local locale overrides
+
+The JSON files in this directory (`en.json`, `de.json`, …) are **local overrides** that win over the central source published by [`@escalated-dev/locale`](https://github.com/escalated-dev/escalated-locale).
+
+The composable in `src/composables/useI18n.js` resolves keys in this order:
+
+1. Host-app `customMessages` for the current locale
+2. Local override (these JSON files) for the current locale
+3. Central source (`@escalated-dev/locale`) for the current locale
+4. Same three layers, but English fallback
+5. Raw key
+
+After the central package is populated with the canonical strings, files here can be trimmed to contain only the keys this plugin needs to phrase differently from the central source. Keys not present locally fall through to the central source unchanged.


### PR DESCRIPTION
## Summary

Wires this frontend to read translations from the central source (`escalated-dev/escalated-locale`) with override fallback.

**Blocked on `escalated-dev/escalated-locale` v0.1.0 publish.** CI will fail until then (npm install cannot resolve `@escalated-dev/locale@^0.1.0`).

After v0.1.0 publishes, mark this PR ready and CI should go green.

## Pattern

`useI18n().t(key, replacements)` (and the `$t` shim used in templates) now resolves a key through this layered chain:

1. **Host-app `customMessages`** for the current locale (`mergeMessages(locale, msgs)` from a host app — top priority).
2. **Local plugin overrides** for the current locale (`src/locales/<lang>.json` — this repo's existing JSON files, retained AS overrides so any string this plugin phrases differently still wins over central).
3. **Central source** for the current locale (`@escalated-dev/locale` — the canonical base layer).
4. Same three layers again as English fallback (when current locale is not `en`).
5. Raw key.

The public composable API is unchanged — every component that calls `useI18n()` keeps working without edits. No translation strings are modified by this PR.

## Why retain `src/locales/*.json` as overrides?

Per the rollout plan, Codex will populate `@escalated-dev/locale` with canonical strings sourced from THIS repo (it is the authoritative origin). Until that consolidation lands, keeping the local JSON files in place means the layered chain still finds every key — there is no UI regression while the central package is empty / partial. After Codex finishes, the local files can be trimmed (or deleted) so the central source becomes the sole source for any key not specifically overridden by this plugin.

## Files changed

- `package.json` — add `@escalated-dev/locale` `^0.1.0` to `dependencies`
- `src/composables/useI18n.js` — three-tier lookup (host customMessages → local overrides → central) with English fallback in the same order
- `src/locales/README.md` — new, documents the override layering
- `CHANGELOG.md` — Unreleased entry

## Test plan

- [ ] Wait for `@escalated-dev/locale` v0.1.0 to publish on npm
- [ ] Mark PR ready for review; verify CI npm install resolves
- [ ] Verify Storybook renders English UI unchanged (local overrides should still win for every existing key)
- [ ] Verify locale switching to a non-en locale (e.g., `de`) still produces translated strings
- [ ] Verify a host-app `mergeMessages('en', {...})` call still wins over both layers
- [ ] Verify a key present ONLY in central (and not in local overrides) is found

## Expected CI failure

`npm ci` / `npm install` will fail with `404 Not Found - GET https://registry.npmjs.org/@escalated-dev%2flocale - Not found` (or equivalent) until the central package publishes v0.1.0. This PR is intentionally a **draft** for that reason.