### PR TITLE
fix(plugin): avoid polynomial ReDoS in scaleBorderRadius

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -94,7 +94,7 @@ function darken(hex, percent) {
 }
 
 function scaleBorderRadius(radius, factor) {
-    const match = radius.match(/^([\d.]+)(.*)$/);
+    const match = radius.match(/^(\d+(?:\.\d+)?|\.\d+)(.*)$/);
     if (!match) return radius;
     return `${(parseFloat(match[1]) * factor).toFixed(2)}${match[2] || 'rem'}`;
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -94,7 +94,7 @@ function darken(hex, percent) {
 }
 
 function scaleBorderRadius(radius, factor) {
-    const match = radius.match(/^(\d+(?:\.\d+)?|\.\d+)(.*)$/);
+    const match = radius.match(/^(\d+(?:\.\d+)?|\.\d+)([a-z%]*)$/i);
     if (!match) return radius;
     return `${(parseFloat(match[1]) * factor).toFixed(2)}${match[2] || 'rem'}`;
 }


### PR DESCRIPTION
## Summary
- Replace ambiguous `[\d.]+` quantifier in `scaleBorderRadius` with an unambiguous number pattern (`\d+(?:\.\d+)?|\.\d+`) so the regex engine cannot backtrack across pathological dot-only input.
- Resolves CodeQL alert `js/polynomial-redos` flagged on `src/plugin.js:97`.

## Test plan
- [ ] CI green
- [ ] CodeQL alert closes after merge