### PR TITLE
fix(customer): surface a staff-panel link when admin/agents land on /support (#60)

### DIFF
--- a/src/pages/Customer/Index.vue
+++ b/src/pages/Customer/Index.vue
@@ -1,9 +1,10 @@
 <script setup>
+import { computed } from 'vue';
 import EscalatedLayout from '../../components/EscalatedLayout.vue';
 import TicketList from '../../components/TicketList.vue';
 import TicketFilters from '../../components/TicketFilters.vue';
 import PluginSlot from '../../components/PluginSlot.vue';
-import { Link } from '@inertiajs/vue3';
+import { Link, usePage } from '@inertiajs/vue3';
 import { usePluginExtensions } from '../../composables/usePluginExtensions';
 
 defineProps({
@@ -12,11 +13,35 @@ defineProps({
 });
 
 const { getPageComponents } = usePluginExtensions();
+const page = usePage();
+const isAdmin = computed(() => !!page.props.escalated?.is_admin);
+const isAgent = computed(() => !!page.props.escalated?.is_agent);
+const staffPanelHref = computed(() => {
+    const prefix = page.props.escalated?.prefix || 'support';
+    const base = prefix.startsWith('/') ? prefix : `/${prefix}`;
+    return isAdmin.value ? `${base}/admin/tickets` : `${base}/agent/tickets`;
+});
+const staffPanelLabel = computed(() => (isAdmin.value ? 'Open admin panel' : 'Open agent panel'));
 </script>
 
 <template>
     <EscalatedLayout title="My Tickets">
         <PluginSlot slot="customer.index.header" :components="getPageComponents('customer.index', 'header')" />
+        <div
+            v-if="isAdmin || isAgent"
+            class="mb-4 flex items-center justify-between gap-4 rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-indigo-900"
+        >
+            <div>
+                <span class="font-medium">You're viewing your personal tickets.</span>
+                <span class="text-indigo-800/80"> Customer-submitted tickets live in the staff panel. </span>
+            </div>
+            <a
+                :href="staffPanelHref"
+                class="shrink-0 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-indigo-700"
+            >
+                {{ staffPanelLabel }}
+            </a>
+        </div>
         <div class="mb-6 flex items-center justify-between">
             <TicketFilters :filters="filters" :route="route('escalated.customer.tickets.index')" />
             <Link


### PR DESCRIPTION
## Summary
- Adds a banner on the customer index (`/support`) that renders only for users who pass the `escalated-admin` or `escalated-agent` gates, with a button to their matching staff panel (`/support/admin/tickets` or `/support/agent/tickets`).
- Closes #60. The customer index scopes its ticket list to the current user, so admins/agents who landed on `/support` saw only their own tickets and concluded that customer-submitted tickets were invisible to staff. Customer tickets are visible in the staff panel — the banner just makes that path obvious.

## Test plan
- [x] `npx vitest run` (522 tests pass)
- [x] Manual: log in as admin, visit `/support`, see the banner, click the button, land on `/support/admin/tickets` with the customer-created ticket visible.
- [x] Manual: log in as agent, visit `/support`, see the banner, click the button, land on `/support/agent/tickets`.
- [x] Manual: log in as a regular customer, visit `/support`, banner is NOT shown.
