### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/escalated-dev/escalated/security/code-scanning/2](https://github.com/escalated-dev/escalated/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege token scopes. For this workflow, `contents: read` is sufficient and is the recommended minimal baseline for checkout/test workflows.

Best fix (no functional change): in `.github/workflows/run-tests.yml`, insert:

```yml
permissions:
  contents: read
```

immediately after the `on:` trigger block (before `jobs:`), so the existing `build` job behavior remains the same while token privileges are explicitly constrained.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
