### PR TITLE
ci(npm-publish): wire NPM_TOKEN secret into NODE_AUTH_TOKEN

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,3 +33,5 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
The npm-publish workflow has been failing on every release (v0.7.1 and v0.8.0 both hit it). Signs the provenance fine, then the `PUT` to the registry returns 404 because the request had no auth header.

OIDC trusted publisher should have worked here, but in practice it hasn't. Wiring the existing `NPM_TOKEN` repo secret into `NODE_AUTH_TOKEN` is the path of least resistance and gets v0.8.0 out the door.

`--provenance` and `--access public` stay on so we keep the supply-chain attestation.

## Test plan
- [ ] Merge → re-run the failed `v0.8.0` publish workflow → confirm `@escalated-dev/escalated@0.8.0` lands on npm.
- [ ] Next release (v0.8.1 / v0.9.0) publishes automatically with no manual step.
