### PR TITLE
feat: add admin skills routing UI

### DIFF
--- a/src/components/SkillTagManager.vue
+++ b/src/components/SkillTagManager.vue
@@ -2,31 +2,35 @@
 import { ref, computed } from 'vue';
 
 const props = defineProps({
-    availableSkills: { type: Array, default: () => [] },
+    items: { type: Array, default: () => [] },
     modelValue: { type: Array, default: () => [] },
+    addLabel: { type: String, default: 'Add Item' },
+    emptyLabel: { type: String, default: 'No items selected' },
+    itemLabelKey: { type: String, default: 'name' },
+    itemValueKey: { type: String, default: 'id' },
 });
 
 const emit = defineEmits(['update:modelValue']);
 
 const showDropdown = ref(false);
 
-const selectedSkills = computed(() => {
-    return props.availableSkills.filter((s) => props.modelValue.includes(s.id));
+const selectedItems = computed(() => {
+    return props.items.filter((item) => props.modelValue.includes(item[props.itemValueKey]));
 });
 
-const unselectedSkills = computed(() => {
-    return props.availableSkills.filter((s) => !props.modelValue.includes(s.id));
+const unselectedItems = computed(() => {
+    return props.items.filter((item) => !props.modelValue.includes(item[props.itemValueKey]));
 });
 
-function addSkill(skillId) {
-    emit('update:modelValue', [...props.modelValue, skillId]);
+function addItem(value) {
+    emit('update:modelValue', [...props.modelValue, value]);
     showDropdown.value = false;
 }
 
-function removeSkill(skillId) {
+function removeItem(value) {
     emit(
         'update:modelValue',
-        props.modelValue.filter((id) => id !== skillId),
+        props.modelValue.filter((id) => id !== value),
     );
 }
 </script>
@@ -36,42 +40,42 @@ function removeSkill(skillId) {
         <!-- Selected skill tags -->
         <div class="flex flex-wrap gap-1.5">
             <span
-                v-for="skill in selectedSkills"
-                :key="skill.id"
+                v-for="item in selectedItems"
+                :key="item[itemValueKey]"
                 class="inline-flex items-center gap-1 rounded-md bg-cyan-500/15 px-2 py-1 text-xs font-medium text-cyan-300 ring-1 ring-cyan-500/20"
             >
-                {{ skill.name }}
+                {{ item[itemLabelKey] }}
                 <button
-                    aria-label="Remove skill"
+                    :aria-label="`Remove ${item[itemLabelKey]}`"
                     class="ml-0.5 text-cyan-400 hover:text-cyan-200"
-                    @click="removeSkill(skill.id)"
+                    @click="removeItem(item[itemValueKey])"
                 >
                     &times;
                 </button>
             </span>
-            <span v-if="!selectedSkills.length" class="text-xs text-neutral-500">No skills assigned</span>
+            <span v-if="!selectedItems.length" class="text-xs text-neutral-500">{{ emptyLabel }}</span>
         </div>
 
         <!-- Add button / dropdown -->
         <div class="relative">
             <button
-                v-if="unselectedSkills.length"
+                v-if="unselectedItems.length"
                 class="rounded-lg border border-dashed border-white/[0.08] px-2 py-1 text-xs text-neutral-400 transition-colors hover:border-white/[0.15] hover:text-neutral-300"
                 @click="showDropdown = !showDropdown"
             >
-                + Add Skill
+                + {{ addLabel }}
             </button>
             <div
-                v-if="showDropdown && unselectedSkills.length"
+                v-if="showDropdown && unselectedItems.length"
                 class="absolute left-0 top-full z-10 mt-1 max-h-40 w-48 overflow-y-auto rounded-lg border border-white/[0.06] bg-neutral-900 py-1 shadow-xl"
             >
                 <button
-                    v-for="skill in unselectedSkills"
-                    :key="skill.id"
+                    v-for="item in unselectedItems"
+                    :key="item[itemValueKey]"
                     class="w-full px-3 py-1.5 text-left text-xs text-neutral-300 transition-colors hover:bg-white/[0.04]"
-                    @click="addSkill(skill.id)"
+                    @click="addItem(item[itemValueKey])"
                 >
-                    {{ skill.name }}
+                    {{ item[itemLabelKey] }}
                 </button>
             </div>
         </div>

--- a/src/pages/Admin/Skills/Form.vue
+++ b/src/pages/Admin/Skills/Form.vue
@@ -1,14 +1,26 @@
 <script setup>
+import { computed } from 'vue';
 import EscalatedLayout from '../../../components/EscalatedLayout.vue';
-import { useForm } from '@inertiajs/vue3';
+import SkillTagManager from '../../../components/SkillTagManager.vue';
+import { Link, useForm } from '@inertiajs/vue3';
 
 const props = defineProps({
     skill: { type: Object, default: null },
+    availableAgents: { type: Array, default: () => [] },
+    availableTags: { type: Array, default: () => [] },
+    availableDepartments: { type: Array, default: () => [] },
 });
 
 const form = useForm({
     name: props.skill?.name || '',
+    routing_tag_ids: props.skill?.routing_tag_ids || [],
+    routing_department_ids: props.skill?.routing_department_ids || [],
+    agents: props.skill?.agents?.length ? props.skill.agents.map((agent) => ({ ...agent })) : [],
 });
+
+const unassignedAgents = computed(() =>
+    props.availableAgents.filter((agent) => !form.agents.some((entry) => entry.user_id === agent.id)),
+);
 
 function submit() {
     if (props.skill) {
@@ -17,11 +29,27 @@ function submit() {
         form.post(route('escalated.admin.skills.store'));
     }
 }
+
+function addAgent() {
+    const nextAgent = unassignedAgents.value[0];
+    if (!nextAgent) {
+        return;
+    }
+
+    form.agents.push({ user_id: nextAgent.id, proficiency: 3 });
+}
+
+function removeAgent(index) {
+    form.agents.splice(index, 1);
+}
 </script>
 
 <template>
     <EscalatedLayout :title="skill ? 'Edit Skill' : 'Create Skill'">
-        <form class="max-w-lg space-y-4" @submit.prevent="submit">
+        <form
+            class="mx-auto max-w-4xl space-y-5 rounded-xl border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface)] p-6"
+            @submit.prevent="submit"
+        >
             <div>
                 <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]">Name</label>
                 <input
@@ -33,6 +61,138 @@ function submit() {
                 <p v-if="form.errors.name" class="mt-1 text-xs text-rose-400">{{ form.errors.name }}</p>
             </div>
 
+            <div class="grid gap-5 lg:grid-cols-2">
+                <div
+                    class="space-y-3 rounded-xl border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface-alt)] p-4"
+                >
+                    <div>
+                        <h2 class="text-sm font-semibold text-[var(--esc-panel-text-secondary)]">Routing Rules</h2>
+                        <p class="mt-1 text-xs text-[var(--esc-panel-text-muted)]">
+                            Match tickets by tag or department to require this skill during auto-assignment.
+                        </p>
+                    </div>
+                    <div>
+                        <label
+                            class="mb-2 block text-xs font-medium uppercase tracking-wide text-[var(--esc-panel-text-muted)]"
+                        >
+                            Required Tags
+                        </label>
+                        <SkillTagManager
+                            v-model="form.routing_tag_ids"
+                            :items="availableTags"
+                            add-label="Add Tag"
+                            empty-label="No ticket tags mapped"
+                        />
+                        <p v-if="form.errors.routing_tag_ids" class="mt-1 text-xs text-rose-400">
+                            {{ form.errors.routing_tag_ids }}
+                        </p>
+                    </div>
+                    <div>
+                        <label
+                            class="mb-2 block text-xs font-medium uppercase tracking-wide text-[var(--esc-panel-text-muted)]"
+                        >
+                            Departments
+                        </label>
+                        <SkillTagManager
+                            v-model="form.routing_department_ids"
+                            :items="availableDepartments"
+                            add-label="Add Department"
+                            empty-label="No departments mapped"
+                        />
+                        <p v-if="form.errors.routing_department_ids" class="mt-1 text-xs text-rose-400">
+                            {{ form.errors.routing_department_ids }}
+                        </p>
+                    </div>
+                </div>
+
+                <div
+                    class="space-y-3 rounded-xl border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface-alt)] p-4"
+                >
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <h2 class="text-sm font-semibold text-[var(--esc-panel-text-secondary)]">
+                                Agent Proficiency
+                            </h2>
+                            <p class="mt-1 text-xs text-[var(--esc-panel-text-muted)]">
+                                Assign eligible agents and tune their proficiency from 1 to 5.
+                            </p>
+                        </div>
+                        <button
+                            v-if="unassignedAgents.length"
+                            type="button"
+                            class="rounded-lg border border-dashed border-[var(--esc-panel-border-input)] px-3 py-1.5 text-xs font-medium text-[var(--esc-panel-text-secondary)] transition-colors hover:bg-[var(--esc-panel-hover)]"
+                            @click="addAgent"
+                        >
+                            Add Agent
+                        </button>
+                    </div>
+
+                    <div v-if="form.agents.length" class="space-y-3">
+                        <div
+                            v-for="(agent, index) in form.agents"
+                            :key="`${agent.user_id}-${index}`"
+                            class="grid gap-3 rounded-lg border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface)] p-3 md:grid-cols-[minmax(0,1fr)_110px_auto]"
+                        >
+                            <div>
+                                <label
+                                    class="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--esc-panel-text-muted)]"
+                                >
+                                    Agent
+                                </label>
+                                <select
+                                    v-model="agent.user_id"
+                                    class="w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                                >
+                                    <option
+                                        v-for="option in [
+                                            ...unassignedAgents,
+                                            availableAgents.find((entry) => entry.id === agent.user_id),
+                                        ].filter(Boolean)"
+                                        :key="option.id"
+                                        :value="option.id"
+                                    >
+                                        {{ option.name }} / {{ option.email }}
+                                    </option>
+                                </select>
+                            </div>
+                            <div>
+                                <label
+                                    class="mb-1 block text-xs font-medium uppercase tracking-wide text-[var(--esc-panel-text-muted)]"
+                                >
+                                    Proficiency
+                                </label>
+                                <select
+                                    v-model="agent.proficiency"
+                                    class="w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                                >
+                                    <option :value="1">1</option>
+                                    <option :value="2">2</option>
+                                    <option :value="3">3</option>
+                                    <option :value="4">4</option>
+                                    <option :value="5">5</option>
+                                </select>
+                            </div>
+                            <div class="flex items-end">
+                                <button
+                                    type="button"
+                                    class="rounded-lg px-3 py-2 text-sm font-medium text-rose-300 transition-colors hover:bg-rose-500/10"
+                                    @click="removeAgent(index)"
+                                >
+                                    Remove
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div
+                        v-else
+                        class="rounded-lg border border-dashed border-[var(--esc-panel-border)] px-4 py-6 text-center text-sm text-[var(--esc-panel-text-muted)]"
+                    >
+                        No agents assigned yet.
+                    </div>
+                </div>
+            </div>
+
             <div class="flex gap-3">
                 <button
                     type="submit"
@@ -41,12 +201,12 @@ function submit() {
                 >
                     {{ skill ? 'Update' : 'Create' }}
                 </button>
-                <a
+                <Link
                     :href="route('escalated.admin.skills.index')"
                     class="rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-hover)] px-4 py-2 text-sm font-medium text-[var(--esc-panel-text-secondary)] transition-colors hover:bg-[var(--esc-panel-hover)]"
                 >
                     Cancel
-                </a>
+                </Link>
             </div>
         </form>
     </EscalatedLayout>

--- a/src/pages/Admin/Skills/Index.vue
+++ b/src/pages/Admin/Skills/Index.vue
@@ -33,7 +33,12 @@ function destroy(id) {
                         <th
                             class="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-[var(--esc-panel-text-muted)]"
                         >
-                            Agents
+                            Routing
+                        </th>
+                        <th
+                            class="px-4 py-3 text-left text-[11px] font-semibold uppercase tracking-wider text-[var(--esc-panel-text-muted)]"
+                        >
+                            Updated
                         </th>
                         <th
                             class="px-4 py-3 text-right text-[11px] font-semibold uppercase tracking-wider text-[var(--esc-panel-text-muted)]"
@@ -44,7 +49,7 @@ function destroy(id) {
                 </thead>
                 <tbody class="divide-y divide-[var(--esc-panel-border)]">
                     <tr v-if="!skills?.length">
-                        <td colspan="3" class="px-4 py-12 text-center">
+                        <td colspan="4" class="px-4 py-12 text-center">
                             <svg
                                 class="mx-auto mb-3 h-8 w-8 text-[var(--esc-panel-text-muted)]"
                                 fill="none"
@@ -73,7 +78,13 @@ function destroy(id) {
                             {{ skill.name }}
                         </td>
                         <td class="px-4 py-3 text-sm text-[var(--esc-panel-text-tertiary)]">
-                            {{ skill.agents_count }}
+                            <div>{{ skill.agents_count }} agents</div>
+                            <div class="text-xs text-[var(--esc-panel-text-muted)]">
+                                {{ skill.routing_tags_count }} tags / {{ skill.routing_departments_count }} departments
+                            </div>
+                        </td>
+                        <td class="px-4 py-3 text-sm text-[var(--esc-panel-text-tertiary)]">
+                            {{ skill.updated_at ? new Date(skill.updated_at).toLocaleDateString() : '-' }}
                         </td>
                         <td class="px-4 py-3 text-right text-sm">
                             <Link


### PR DESCRIPTION
## Summary
- add admin form support for routing tags and departments
- add skill agent proficiency management in the admin UI
- refresh the skills index to show routing coverage and edit actions

## Verification
- npm run lint -- src/components/SkillTagManager.vue src/pages/Admin/Skills/Form.vue src/pages/Admin/Skills/Index.vue