### PR TITLE
feat: expand admin SSO settings UI

### DIFF
--- a/src/pages/Admin/Settings/SsoSettings.vue
+++ b/src/pages/Admin/Settings/SsoSettings.vue
@@ -8,13 +8,33 @@ const form = useForm({
     sso_provider: props.settings.sso_provider ?? 'none',
     sso_entity_id: props.settings.sso_entity_id ?? '',
     sso_url: props.settings.sso_url ?? '',
+    sso_login_url: props.settings.sso_login_url ?? props.settings.sso_url ?? '',
+    sso_logout_url: props.settings.sso_logout_url ?? '',
+    sso_metadata_url: props.settings.sso_metadata_url ?? '',
     sso_certificate: props.settings.sso_certificate ?? '',
     sso_attr_email: props.settings.sso_attr_email ?? 'email',
     sso_attr_name: props.settings.sso_attr_name ?? 'name',
     sso_attr_role: props.settings.sso_attr_role ?? 'role',
     sso_jwt_secret: props.settings.sso_jwt_secret ?? '',
     sso_jwt_algorithm: props.settings.sso_jwt_algorithm ?? 'HS256',
+    sso_oauth_authorize_url: props.settings.sso_oauth_authorize_url ?? '',
+    sso_oauth_token_url: props.settings.sso_oauth_token_url ?? '',
+    sso_oauth_userinfo_url: props.settings.sso_oauth_userinfo_url ?? '',
+    sso_oauth_client_id: props.settings.sso_oauth_client_id ?? '',
+    sso_oauth_client_secret: props.settings.sso_oauth_client_secret ?? '',
+    sso_oauth_scopes: props.settings.sso_oauth_scopes ?? 'openid profile email',
 });
+
+function readCertificate(event) {
+    const [file] = event.target.files ?? [];
+    if (!file) return;
+
+    const reader = new window.FileReader();
+    reader.onload = () => {
+        form.sso_certificate = typeof reader.result === 'string' ? reader.result : '';
+    };
+    reader.readAsText(file);
+}
 
 function submit() {
     form.post(route('escalated.admin.settings.sso.update'));
@@ -42,6 +62,7 @@ function submit() {
                             <option value="none">None (disabled)</option>
                             <option value="saml">SAML 2.0</option>
                             <option value="jwt">JWT</option>
+                            <option value="oauth">OAuth 2.0 / OIDC</option>
                         </select>
                     </div>
                 </div>
@@ -72,16 +93,48 @@ function submit() {
                         </div>
                     </div>
                     <div>
-                        <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]">SSO URL</label>
+                        <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                            >Login URL</label
+                        >
                         <p class="mt-0.5 text-xs text-[var(--esc-panel-text-muted)]">The Single Sign-On URL endpoint</p>
                         <input
-                            v-model="form.sso_url"
+                            v-model="form.sso_login_url"
                             type="url"
                             placeholder="https://idp.example.com/sso"
                             class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
                         />
-                        <div v-if="form.errors.sso_url" class="mt-1 text-sm text-rose-400">
-                            {{ form.errors.sso_url }}
+                        <div v-if="form.errors.sso_login_url" class="mt-1 text-sm text-rose-400">
+                            {{ form.errors.sso_login_url }}
+                        </div>
+                    </div>
+                    <div class="grid gap-5 md:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Logout URL</label
+                            >
+                            <input
+                                v-model="form.sso_logout_url"
+                                type="url"
+                                placeholder="https://idp.example.com/logout"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                            <div v-if="form.errors.sso_logout_url" class="mt-1 text-sm text-rose-400">
+                                {{ form.errors.sso_logout_url }}
+                            </div>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Metadata URL</label
+                            >
+                            <input
+                                v-model="form.sso_metadata_url"
+                                type="url"
+                                placeholder="https://idp.example.com/metadata"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                            <div v-if="form.errors.sso_metadata_url" class="mt-1 text-sm text-rose-400">
+                                {{ form.errors.sso_metadata_url }}
+                            </div>
                         </div>
                     </div>
                     <div>
@@ -91,6 +144,12 @@ function submit() {
                         <p class="mt-0.5 text-xs text-[var(--esc-panel-text-muted)]">
                             X.509 certificate from your Identity Provider (PEM format)
                         </p>
+                        <input
+                            type="file"
+                            accept=".pem,.crt,.cer,.txt"
+                            class="mt-2 block text-xs text-[var(--esc-panel-text-muted)]"
+                            @change="readCertificate"
+                        />
                         <textarea
                             v-model="form.sso_certificate"
                             rows="6"
@@ -139,6 +198,8 @@ function submit() {
                             <option value="HS384">HS384</option>
                             <option value="HS512">HS512</option>
                             <option value="RS256">RS256</option>
+                            <option value="RS384">RS384</option>
+                            <option value="RS512">RS512</option>
                         </select>
                     </div>
                     <div>
@@ -152,6 +213,98 @@ function submit() {
                             placeholder="https://auth.example.com/jwt-sso"
                             class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
                         />
+                    </div>
+                </div>
+            </div>
+
+            <div
+                v-if="form.sso_provider === 'oauth'"
+                class="rounded-xl border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface)] p-6"
+            >
+                <h3 class="mb-5 text-sm font-semibold text-[var(--esc-panel-text)]">OAuth / OIDC Configuration</h3>
+                <div class="space-y-5">
+                    <div class="grid gap-5 md:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Authorize URL</label
+                            >
+                            <input
+                                v-model="form.sso_oauth_authorize_url"
+                                type="url"
+                                placeholder="https://idp.example.com/oauth/authorize"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                            <div v-if="form.errors.sso_oauth_authorize_url" class="mt-1 text-sm text-rose-400">
+                                {{ form.errors.sso_oauth_authorize_url }}
+                            </div>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Token URL</label
+                            >
+                            <input
+                                v-model="form.sso_oauth_token_url"
+                                type="url"
+                                placeholder="https://idp.example.com/oauth/token"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                            <div v-if="form.errors.sso_oauth_token_url" class="mt-1 text-sm text-rose-400">
+                                {{ form.errors.sso_oauth_token_url }}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="grid gap-5 md:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Userinfo URL</label
+                            >
+                            <input
+                                v-model="form.sso_oauth_userinfo_url"
+                                type="url"
+                                placeholder="https://idp.example.com/oauth/userinfo"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                            <div v-if="form.errors.sso_oauth_userinfo_url" class="mt-1 text-sm text-rose-400">
+                                {{ form.errors.sso_oauth_userinfo_url }}
+                            </div>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Scopes</label
+                            >
+                            <input
+                                v-model="form.sso_oauth_scopes"
+                                type="text"
+                                placeholder="openid profile email"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                        </div>
+                    </div>
+                    <div class="grid gap-5 md:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Client ID</label
+                            >
+                            <input
+                                v-model="form.sso_oauth_client_id"
+                                type="text"
+                                placeholder="escalated-admin"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] placeholder-[var(--esc-panel-text-muted)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                            <div v-if="form.errors.sso_oauth_client_id" class="mt-1 text-sm text-rose-400">
+                                {{ form.errors.sso_oauth_client_id }}
+                            </div>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-[var(--esc-panel-text-secondary)]"
+                                >Client Secret</label
+                            >
+                            <input
+                                v-model="form.sso_oauth_client_secret"
+                                type="password"
+                                class="mt-2 w-full rounded-lg border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-sm text-[var(--esc-panel-text-secondary)] focus:border-[var(--esc-panel-border-input)] focus:outline-none focus:ring-1 focus:ring-[var(--esc-panel-border-input)]"
+                            />
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add OAuth and richer SAML settings to the admin SSO page
- support PEM certificate file loading in the browser
- expose endpoint and attribute mapping fields for each provider mode

## Verification
- npm run lint -- src/pages/Admin/Settings/SsoSettings.vue