### PR TITLE
fix: tighten two-factor setup flow

### DIFF
--- a/src/components/TwoFactorSetup.vue
+++ b/src/components/TwoFactorSetup.vue
@@ -2,9 +2,8 @@
 import { ref } from 'vue';
 import TotpInput from './TotpInput.vue';
 
-const props = defineProps({
+defineProps({
     qrUri: { type: String, default: '' },
-    recoveryCodes: { type: Array, default: () => [] },
 });
 
 const emit = defineEmits(['confirm', 'cancel']);
@@ -24,12 +23,6 @@ function confirmCode() {
     }
     error.value = '';
     emit('confirm', code.value);
-    step.value = 3;
-}
-
-function copyRecoveryCodes() {
-    const text = props.recoveryCodes.join('\n');
-    navigator.clipboard?.writeText(text);
 }
 </script>
 
@@ -77,35 +70,6 @@ function copyRecoveryCodes() {
                     @click="emit('cancel')"
                 >
                     Cancel
-                </button>
-            </div>
-        </div>
-
-        <!-- Step 3: Recovery Codes -->
-        <div v-if="step === 3">
-            <h3 class="mb-4 text-sm font-semibold text-white">Step 3: Save Recovery Codes</h3>
-            <p class="mb-4 text-sm text-neutral-400">
-                Save these recovery codes in a safe place. Each code can only be used once to access your account if you
-                lose your authenticator device.
-            </p>
-            <div class="rounded-lg border border-white/[0.06] bg-neutral-950 p-4">
-                <div class="grid grid-cols-2 gap-2">
-                    <code
-                        v-for="(rc, idx) in recoveryCodes"
-                        :key="idx"
-                        class="rounded bg-neutral-900 px-3 py-1.5 text-center text-sm font-mono text-neutral-200"
-                    >
-                        {{ rc }}
-                    </code>
-                </div>
-            </div>
-            <div class="mt-4 flex gap-3">
-                <button
-                    type="button"
-                    class="rounded-lg border border-white/10 px-4 py-2 text-sm text-neutral-400 hover:text-neutral-200"
-                    @click="copyRecoveryCodes"
-                >
-                    Copy Codes
                 </button>
             </div>
         </div>

--- a/src/pages/Admin/Settings/TwoFactor.vue
+++ b/src/pages/Admin/Settings/TwoFactor.vue
@@ -12,6 +12,7 @@ defineProps({
 const page = usePage();
 const showSetup = ref(false);
 const setupData = computed(() => page.props.flash?.two_factor_setup);
+const confirmedData = computed(() => page.props.flash?.two_factor_confirmed);
 
 function startSetup() {
     router.post(
@@ -98,12 +99,37 @@ function disable() {
                 v-if="setupData && !enabled"
                 class="rounded-xl border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface)] p-6"
             >
-                <TwoFactorSetup
-                    :qr-uri="setupData.qr_uri"
-                    :recovery-codes="setupData.recovery_codes"
-                    @confirm="confirmCode"
-                    @cancel="showSetup = false"
-                />
+                <TwoFactorSetup :qr-uri="setupData.qr_uri" @confirm="confirmCode" @cancel="showSetup = false" />
+            </div>
+
+            <div
+                v-if="confirmedData?.recovery_codes?.length"
+                class="rounded-xl border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface)] p-6"
+            >
+                <div class="flex items-start justify-between gap-4">
+                    <div>
+                        <h3 class="text-sm font-semibold text-[var(--esc-panel-text)]">Recovery Codes</h3>
+                        <p class="mt-2 text-sm text-[var(--esc-panel-text-tertiary)]">
+                            Save these codes now. Each one can be used once if you lose access to your authenticator.
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        class="rounded-lg border border-[var(--esc-panel-border)] px-4 py-2 text-sm text-[var(--esc-panel-text-secondary)] hover:bg-[var(--esc-panel-surface-alt)]"
+                        @click="navigator.clipboard?.writeText(confirmedData.recovery_codes.join('\n'))"
+                    >
+                        Copy Codes
+                    </button>
+                </div>
+                <div class="mt-4 grid gap-2 md:grid-cols-2">
+                    <code
+                        v-for="code in confirmedData.recovery_codes"
+                        :key="code"
+                        class="rounded-lg bg-[var(--esc-panel-surface-alt)] px-3 py-2 text-center text-sm font-mono text-[var(--esc-panel-text-secondary)]"
+                    >
+                        {{ code }}
+                    </code>
+                </div>
             </div>
         </div>
     </EscalatedLayout>


### PR DESCRIPTION
## Summary
- keep the setup wizard focused on scan and verify steps
- show recovery codes from the successful confirmation response
- keep copy behavior on the settings page instead of pre-confirmation

## Verification
- npm run lint -- src/components/TwoFactorSetup.vue src/pages/Admin/Settings/TwoFactor.vue