### PR TITLE
docs(readme): expand Tailwind section with non-build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ Each backend repo has full setup instructions — install command, migrations, c
 
 ## Tailwind CSS
 
-Escalated components use Tailwind CSS classes. You **must** add this package to your Tailwind `content` config so its classes aren't purged:
+Escalated components use Tailwind CSS utility classes (~hundreds of them across 140+ Vue files). **Some Tailwind-compatible class processor must be available in the host app for the UI to render correctly** — without one, every component renders as unstyled DOM with class names that don't resolve to any CSS.
+
+### Recommended: Tailwind in your existing build
+
+If your host app already uses Tailwind via Vite / PostCSS / Tailwind CLI, just add this package to your `content` config so its classes aren't purged:
 
 ```js
 // tailwind.config.js
@@ -77,7 +81,22 @@ export default {
 }
 ```
 
-Without this, Escalated UI will render but styles like button backgrounds and badge colors will be missing.
+> **Tailwind 4+ users:** `content` globs are auto-detected from imported modules — you usually don't need to add anything. Skip this step if you're on v4.
+
+### Using Escalated without a Tailwind build step
+
+If you don't want a Tailwind toolchain in your build pipeline, you have a few options. Each has trade-offs — pick the one closest to your project's constraints:
+
+| Option | When to use | How |
+|---|---|---|
+| **Tailwind Play CDN** | Prototyping, internal tools, demos. Not recommended for production (no purging, ~3 MB script tag). | Add `<script src="https://cdn.tailwindcss.com"></script>` to the page that renders Escalated. The CDN script JIT-compiles classes at runtime. |
+| **Tailwind standalone CLI** | You want a static stylesheet without npm/Vite. | Download the [standalone CLI binary](https://tailwindcss.com/blog/standalone-cli) and run `tailwindcss -i input.css -o public/escalated.css --content './node_modules/@escalated-dev/escalated/src/**/*.vue' --minify`. Link the output stylesheet from your page. |
+| **UnoCSS / Twind in attributify mode** | Already using one of these atomic-CSS engines. | Configure with the Tailwind preset (`@unocss/preset-wind` or `@twind/preset-tailwind`) and add the Escalated package path to the engine's scan config. Class semantics match. |
+| **Forking with hand-rolled CSS** | You categorically cannot ship any Tailwind-compatible tooling and are willing to maintain a fork. | Replace utility classes with scoped CSS per component. Substantial effort; not officially supported. |
+
+If none of these fit, please [open a discussion](https://github.com/escalated-dev/escalated/discussions) so we can understand the constraint and consider a pre-compiled CSS distribution.
+
+Whatever path you choose, also make sure the [theme tokens](#theming) (CSS custom properties) are applied — those control colour, spacing, and radius and are independent of Tailwind.
 
 ## Theming
 


### PR DESCRIPTION
## Summary
Closes the 2026-05-13 follow-up to document how to use Escalated **without** a Tailwind build step in the host app.

Four documented options, each with honest trade-offs:

| Option | When to use |
|---|---|
| Tailwind Play CDN | Prototyping, internal tools |
| Tailwind standalone CLI | Static stylesheet, no npm/Vite |
| UnoCSS / Twind | Already using an atomic-CSS engine |
| Forking with hand-rolled CSS | Last resort |

Also clarifies that **Tailwind 4 auto-detects content globs**, so the explicit \`content\` path that the previous docs required isn't necessary on v4.

Companion change to the docs site (escalated-docs) is in a separate PR.

## Test plan
- [ ] Render README on github.com; confirm the Tailwind section markdown table renders correctly.
- [ ] Spot-check the CDN snippet on a vanilla HTML page hosting a small Escalated demo to confirm the unstyled-vs-styled boundary lands where the doc claims.