### PR TITLE
feat(tickets): render custom ticket actions on agent screen

### DIFF
--- a/src/components/CustomTicketActions.stories.js
+++ b/src/components/CustomTicketActions.stories.js
@@ -1,0 +1,71 @@
+import CustomTicketActions from './CustomTicketActions.vue';
+
+export default {
+    title: 'Components/CustomTicketActions',
+    component: CustomTicketActions,
+};
+
+const baseAction = {
+    confirmation: null,
+    disabled: false,
+    metadata: {},
+    method: 'post',
+};
+
+export const Default = {
+    args: {
+        actions: [
+            {
+                ...baseAction,
+                key: 'sync-crm',
+                label: 'Sync CRM',
+                variant: 'primary',
+                metadata: { icon: 'refresh-cw' },
+                url: '#',
+            },
+            {
+                ...baseAction,
+                key: 'export',
+                label: 'Export',
+                variant: 'secondary',
+                url: '#',
+            },
+        ],
+    },
+};
+
+export const WithConfirmationAndDanger = {
+    args: {
+        actions: [
+            {
+                ...baseAction,
+                key: 'archive',
+                label: 'Archive',
+                variant: 'danger',
+                confirmation: 'Archive this ticket?',
+                url: '#',
+            },
+        ],
+    },
+};
+
+export const Disabled = {
+    args: {
+        actions: [
+            {
+                ...baseAction,
+                key: 'locked',
+                label: 'Already synced',
+                variant: 'secondary',
+                disabled: true,
+                url: '#',
+            },
+        ],
+    },
+};
+
+export const Empty = {
+    args: {
+        actions: [],
+    },
+};

--- a/src/components/CustomTicketActions.vue
+++ b/src/components/CustomTicketActions.vue
@@ -1,0 +1,101 @@
+<script setup>
+import { ref, computed, inject } from 'vue';
+import { router } from '@inertiajs/vue3';
+
+/**
+ * Renders host-application defined action buttons on the agent ticket screen.
+ *
+ * Each action is provided by the backend's ticket action registry and exposed
+ * on the ticket show props as `customActions`. Clicking a button (after an
+ * optional confirmation) POSTs to the action's `url`, which dispatches the
+ * backend `TicketCustomActionTriggered` event so the host app can handle it.
+ *
+ * @typedef {Object} CustomAction
+ * @property {string} key - Unique identifier for the action.
+ * @property {string} label - Pre-localized button label from the backend.
+ * @property {string} variant - Button style: 'primary' | 'secondary' | 'danger'.
+ * @property {string|null} confirmation - Optional pre-localized confirmation prompt.
+ * @property {boolean} disabled - Whether the button is non-interactive.
+ * @property {Object} metadata - Extra data from the action (e.g. `icon`).
+ * @property {string} url - Endpoint the action POSTs to.
+ * @property {string} method - HTTP method, currently always 'post'.
+ */
+
+defineProps({
+    actions: { type: Array, default: () => [] },
+});
+
+const escDark = inject(
+    'esc-dark',
+    computed(() => false),
+);
+
+// Key of the action currently submitting, so we only disable the clicked button.
+const processingKey = ref(null);
+
+function variantClasses(variant) {
+    switch (variant) {
+        case 'primary':
+            return 'bg-gradient-to-r from-cyan-500 to-violet-500 text-white shadow-lg shadow-black/20 hover:from-cyan-400 hover:to-violet-400';
+        case 'danger':
+            return escDark.value
+                ? 'bg-rose-500/15 text-rose-400 ring-1 ring-rose-500/20 hover:bg-rose-500/25'
+                : 'bg-rose-50 text-rose-600 ring-1 ring-rose-200 hover:bg-rose-100';
+        case 'secondary':
+        default:
+            return escDark.value
+                ? 'border border-[var(--esc-panel-border-input)] bg-[var(--esc-panel-hover)] text-[var(--esc-panel-text-secondary)] hover:bg-[var(--esc-panel-hover)]'
+                : 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50';
+    }
+}
+
+function trigger(action) {
+    if (action.disabled || processingKey.value || !action.url) return;
+    if (action.confirmation && !window.confirm(action.confirmation)) return;
+
+    processingKey.value = action.key;
+    router.post(
+        action.url,
+        {},
+        {
+            preserveScroll: true,
+            onFinish: () => {
+                processingKey.value = null;
+            },
+        },
+    );
+}
+</script>
+
+<template>
+    <button
+        v-for="action in actions"
+        :key="action.key"
+        type="button"
+        :disabled="action.disabled || processingKey === action.key"
+        :data-action-key="action.key"
+        :class="[
+            'inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-sm font-medium transition-all',
+            variantClasses(action.variant),
+            (action.disabled || processingKey === action.key) && 'cursor-not-allowed opacity-50',
+        ]"
+        @click="trigger(action)"
+    >
+        <svg
+            v-if="action.metadata && action.metadata.icon"
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+        >
+            <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+            />
+        </svg>
+        <span>{{ action.label }}</span>
+    </button>
+</template>

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ export { default as ConditionalFieldRules } from './components/ConditionalFieldR
 export { default as ContextPanel } from './components/ContextPanel.vue';
 export { default as ContextPanelSection } from './components/ContextPanelSection.vue';
 export { default as CustomFieldRenderer } from './components/CustomFieldRenderer.vue';
+export { default as CustomTicketActions } from './components/CustomTicketActions.vue';
 export { default as EscalatedLayout } from './components/EscalatedLayout.vue';
 export { default as FileDropzone } from './components/FileDropzone.vue';
 export { default as FollowButton } from './components/FollowButton.vue';

--- a/src/pages/Agent/TicketShow.vue
+++ b/src/pages/Agent/TicketShow.vue
@@ -10,6 +10,7 @@ import ChatActionBar from '../../components/ChatActionBar.vue';
 import TicketSidebar from '../../components/TicketSidebar.vue';
 import AttachmentList from '../../components/AttachmentList.vue';
 import MacroDropdown from '../../components/MacroDropdown.vue';
+import CustomTicketActions from '../../components/CustomTicketActions.vue';
 import FollowButton from '../../components/FollowButton.vue';
 import PresenceIndicator from '../../components/PresenceIndicator.vue';
 import PinnedNotes from '../../components/PinnedNotes.vue';
@@ -31,6 +32,7 @@ const props = defineProps({
     tags: Array,
     cannedResponses: Array,
     macros: { type: Array, default: () => [] },
+    customActions: { type: Array, default: () => [] },
     is_following: { type: Boolean, default: false },
     followers_count: { type: Number, default: 0 },
 });
@@ -253,6 +255,8 @@ onMounted(() => {
                         <option value="critical">Critical</option>
                     </select>
                 </template>
+                <!-- Host-defined custom ticket actions -->
+                <CustomTicketActions :actions="customActions" />
                 <!-- Context Panel Toggle -->
                 <button
                     type="button"

--- a/tests/components/CustomTicketActions.test.js
+++ b/tests/components/CustomTicketActions.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { computed } from 'vue';
+
+const post = vi.fn();
+vi.mock('@inertiajs/vue3', () => ({
+    router: {
+        post: (...args) => post(...args),
+    },
+}));
+
+import CustomTicketActions from '../../src/components/CustomTicketActions.vue';
+
+const actions = [
+    {
+        key: 'sync-crm',
+        label: 'Sync CRM',
+        variant: 'primary',
+        confirmation: null,
+        disabled: false,
+        metadata: { icon: 'refresh-cw' },
+        url: '/support/agent/tickets/TK-1/actions/sync-crm',
+        method: 'post',
+    },
+    {
+        key: 'archive',
+        label: 'Archive',
+        variant: 'danger',
+        confirmation: 'Archive this ticket?',
+        disabled: false,
+        metadata: {},
+        url: '/support/agent/tickets/TK-1/actions/archive',
+        method: 'post',
+    },
+    {
+        key: 'locked',
+        label: 'Locked',
+        variant: 'secondary',
+        confirmation: null,
+        disabled: true,
+        metadata: {},
+        url: '/support/agent/tickets/TK-1/actions/locked',
+        method: 'post',
+    },
+];
+
+function mountActions(props = {}, dark = false) {
+    return mount(CustomTicketActions, {
+        props: { actions, ...props },
+        global: {
+            provide: {
+                'esc-dark': computed(() => dark),
+            },
+        },
+    });
+}
+
+describe('CustomTicketActions', () => {
+    beforeEach(() => {
+        post.mockClear();
+    });
+
+    describe('rendering', () => {
+        it('renders a button per action with its label', () => {
+            const wrapper = mountActions();
+            const buttons = wrapper.findAll('button');
+            expect(buttons).toHaveLength(3);
+            expect(wrapper.text()).toContain('Sync CRM');
+            expect(wrapper.text()).toContain('Archive');
+        });
+
+        it('renders an icon when metadata.icon is present', () => {
+            const wrapper = mountActions();
+            const syncButton = wrapper.get('[data-action-key="sync-crm"]');
+            expect(syncButton.find('svg').exists()).toBe(true);
+        });
+
+        it('disables actions flagged as disabled', () => {
+            const wrapper = mountActions();
+            const locked = wrapper.get('[data-action-key="locked"]');
+            expect(locked.attributes('disabled')).toBeDefined();
+        });
+
+        it('renders nothing when there are no actions', () => {
+            const wrapper = mountActions({ actions: [] });
+            expect(wrapper.findAll('button')).toHaveLength(0);
+        });
+    });
+
+    describe('triggering', () => {
+        it('POSTs to the action url when clicked', async () => {
+            const wrapper = mountActions();
+            await wrapper.get('[data-action-key="sync-crm"]').trigger('click');
+            expect(post).toHaveBeenCalledTimes(1);
+            expect(post.mock.calls[0][0]).toBe('/support/agent/tickets/TK-1/actions/sync-crm');
+        });
+
+        it('does not POST when a disabled action is clicked', async () => {
+            const wrapper = mountActions();
+            await wrapper.get('[data-action-key="locked"]').trigger('click');
+            expect(post).not.toHaveBeenCalled();
+        });
+
+        it('asks for confirmation and aborts when declined', async () => {
+            const confirmSpy = vi.fn().mockReturnValue(false);
+            vi.stubGlobal('confirm', confirmSpy);
+            const wrapper = mountActions();
+            await wrapper.get('[data-action-key="archive"]').trigger('click');
+            expect(confirmSpy).toHaveBeenCalledWith('Archive this ticket?');
+            expect(post).not.toHaveBeenCalled();
+            vi.unstubAllGlobals();
+        });
+
+        it('POSTs after confirmation is accepted', async () => {
+            vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+            const wrapper = mountActions();
+            await wrapper.get('[data-action-key="archive"]').trigger('click');
+            expect(post).toHaveBeenCalledTimes(1);
+            vi.unstubAllGlobals();
+        });
+    });
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -74,6 +74,7 @@ describe('index.js exports', () => {
         'ContextPanel',
         'ContextPanelSection',
         'CustomFieldRenderer',
+        'CustomTicketActions',
         'EscalatedLayout',
         'FileDropzone',
         'FollowButton',
@@ -120,8 +121,8 @@ describe('index.js exports', () => {
             expect(typeof component).toBe('object');
         });
 
-        it('exports exactly 54 components', () => {
-            expect(expectedComponents).toHaveLength(54);
+        it('exports exactly 55 components', () => {
+            expect(expectedComponents).toHaveLength(55);
             for (const name of expectedComponents) {
                 expect(escalated[name]).toBeDefined();
             }
@@ -141,8 +142,8 @@ describe('index.js exports', () => {
 
         it('total named exports equals components + plugin + composables + helper', () => {
             const keys = Object.keys(escalated);
-            // 55 components + 2 saved-view components + 1 plugin + 7 composables + 1 helper + 5 pages + 6 utils = 77
-            expect(keys).toHaveLength(77);
+            // 56 components + 2 saved-view components + 1 plugin + 7 composables + 1 helper + 5 pages + 6 utils = 78
+            expect(keys).toHaveLength(78);
         });
 
         it('every export key is a non-empty string', () => {


### PR DESCRIPTION
Frontend counterpart to **escalated-laravel#107** (Custom Ticket Actions via Events). This is the shared `@escalated-dev/escalated` UI consumed identically by every host framework, so it lands once here.

## What
Adds a `CustomTicketActions` component that renders host-application defined action buttons in the agent ticket show header. It consumes the new `customActions` prop the backend exposes on the agent show page. Each item:

```js
{ key, label, variant, confirmation, disabled, metadata, url, method: 'post' }
```

- Renders one button per action, styled by `variant` (`primary` gradient / `secondary` border / `danger` rose), with dark-mode support via the existing `esc-dark` inject.
- Prompts via `window.confirm(action.confirmation)` when the action defines a confirmation (matching the existing `SavedViewSidebar` precedent).
- Honors `disabled` and shows a per-button processing state.
- POSTs to `action.url` via Inertia `router.post` (preserveScroll), which dispatches the backend `TicketCustomActionTriggered` event.
- Renders an optional icon glyph when `metadata.icon` is present.

## Wiring
- New component exported from `src/index.js`.
- Imported into `src/pages/Agent/TicketShow.vue` with a new `customActions` prop, rendered in the action bar alongside macros/assign/status.

## Testing
- New Vitest suite (`tests/components/CustomTicketActions.test.js`): render, icon, disabled, confirmation accept/decline, POST behavior.
- Updated `tests/index.test.js` export counts for the new component.
- Storybook story with variant/confirmation/disabled/empty cases.
- `vitest run` — **532 passed**; `eslint --max-warnings 0` clean (pre-commit hooks also pass).

## Note
Backend exposes the prop as `customActions` (agent show) / `custom_actions` (API). This component reads the camelCase `customActions` prop delivered to the agent page.