### PR TITLE
feat(tickets): render attached ticket subjects in the sidebar (#89)

### DIFF
--- a/src/components/TicketSidebar.vue
+++ b/src/components/TicketSidebar.vue
@@ -7,6 +7,7 @@ import AssigneeSelect from './AssigneeSelect.vue';
 import TagSelect from './TagSelect.vue';
 import TicketTypeSelector from './TicketTypeSelector.vue';
 import ActivityTimeline from './ActivityTimeline.vue';
+import TicketSubjects from './TicketSubjects.vue';
 
 defineProps({
     ticket: { type: Object, required: true },
@@ -84,6 +85,9 @@ function renderStars(rating) {
                 </div>
             </dl>
         </div>
+
+        <!-- Related host-app entities this ticket is about (Project, Customer, …) -->
+        <TicketSubjects :subjects="ticket.subjects || []" />
 
         <!-- Satisfaction Rating (read-only) -->
         <div v-if="ticket.satisfaction_rating" :class="cardClass">

--- a/src/components/TicketSubjects.stories.js
+++ b/src/components/TicketSubjects.stories.js
@@ -1,0 +1,63 @@
+import TicketSubjects from './TicketSubjects.vue';
+
+export default {
+    title: 'Components/TicketSubjects',
+    component: TicketSubjects,
+};
+
+export const Single = {
+    args: {
+        subjects: [
+            {
+                type: 'App\\Models\\Project',
+                id: '42',
+                role: 'project',
+                title: 'Acme Website Redesign',
+                subtitle: 'Project · Acme Corp',
+                url: 'https://app.example.com/projects/42',
+                color: '#2563eb',
+                icon: 'folder',
+            },
+        ],
+    },
+};
+
+export const Multiple = {
+    args: {
+        subjects: [
+            {
+                type: 'App\\Models\\Project',
+                id: '42',
+                role: 'project',
+                title: 'Acme Website Redesign',
+                subtitle: 'Project · Acme Corp',
+                url: 'https://app.example.com/projects/42',
+                color: '#2563eb',
+                icon: 'folder',
+            },
+            {
+                type: 'App\\Models\\Customer',
+                id: '7',
+                role: 'account',
+                title: 'Acme Corp',
+                subtitle: 'Enterprise · 320 seats',
+                url: 'https://app.example.com/customers/7',
+                color: '#059669',
+                icon: 'building',
+            },
+            {
+                type: 'App\\Models\\Asset',
+                id: 'srv-19',
+                title: 'web-prod-19',
+                subtitle: 'Server · us-east-1',
+                url: null,
+                color: null,
+                icon: null,
+            },
+        ],
+    },
+};
+
+export const Empty = {
+    args: { subjects: [] },
+};

--- a/src/components/TicketSubjects.vue
+++ b/src/components/TicketSubjects.vue
@@ -1,0 +1,107 @@
+<script setup>
+import { inject, computed } from 'vue';
+
+const props = defineProps({
+    subjects: { type: Array, default: () => [] },
+});
+
+const escDark = inject(
+    'esc-dark',
+    computed(() => false),
+);
+
+const cardClass = computed(() =>
+    escDark.value
+        ? 'rounded-xl border border-[var(--esc-panel-border)] bg-[var(--esc-panel-surface)] p-4'
+        : 'rounded-lg border border-gray-200 bg-white p-4',
+);
+
+const hasSubjects = computed(() => Array.isArray(props.subjects) && props.subjects.length > 0);
+
+function initials(subject) {
+    const text = (subject.title || '').trim();
+    if (!text) return '?';
+    return text
+        .split(/\s+/)
+        .slice(0, 2)
+        .map((w) => w.charAt(0).toUpperCase())
+        .join('');
+}
+</script>
+
+<template>
+    <div v-if="hasSubjects" :class="cardClass">
+        <h3 :class="['mb-3 text-sm font-semibold', escDark ? 'text-[var(--esc-panel-text)]' : 'text-gray-900']">
+            Related
+        </h3>
+        <ul class="space-y-2">
+            <li v-for="(subject, i) in subjects" :key="`${subject.type}:${subject.id}:${i}`">
+                <component
+                    :is="subject.url ? 'a' : 'div'"
+                    :href="subject.url || undefined"
+                    :target="subject.url ? '_blank' : undefined"
+                    :rel="subject.url ? 'noopener noreferrer' : undefined"
+                    :class="[
+                        'flex items-center gap-3 rounded-md px-2 py-1.5 text-sm transition',
+                        subject.url ? 'cursor-pointer' : '',
+                        subject.url
+                            ? escDark
+                                ? 'hover:bg-[var(--esc-panel-hover,rgba(255,255,255,0.05))]'
+                                : 'hover:bg-gray-50'
+                            : '',
+                    ]"
+                >
+                    <span
+                        class="flex h-8 w-8 flex-none items-center justify-center rounded-md text-xs font-semibold text-white"
+                        :style="{ backgroundColor: subject.color || '#6b7280' }"
+                        :title="subject.icon || undefined"
+                        aria-hidden="true"
+                    >
+                        {{ initials(subject) }}
+                    </span>
+                    <span class="min-w-0 flex-1">
+                        <span
+                            :class="[
+                                'block truncate font-medium',
+                                escDark ? 'text-[var(--esc-panel-text)]' : 'text-gray-900',
+                            ]"
+                        >
+                            {{ subject.title }}
+                        </span>
+                        <span
+                            v-if="subject.subtitle"
+                            :class="[
+                                'block truncate text-xs',
+                                escDark ? 'text-[var(--esc-panel-text-muted)]' : 'text-gray-500',
+                            ]"
+                        >
+                            {{ subject.subtitle }}
+                        </span>
+                    </span>
+                    <span
+                        v-if="subject.role"
+                        :class="['flex-none text-xs', escDark ? 'text-[var(--esc-panel-text-muted)]' : 'text-gray-400']"
+                    >
+                        {{ subject.role }}
+                    </span>
+                    <svg
+                        v-if="subject.url"
+                        class="h-3.5 w-3.5 flex-none"
+                        :class="escDark ? 'text-[var(--esc-panel-text-muted)]' : 'text-gray-400'"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        aria-hidden="true"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            d="M14 5h5v5m0-5L10 14m-1 5H6a2 2 0 01-2-2V8"
+                        />
+                    </svg>
+                </component>
+            </li>
+        </ul>
+    </div>
+</template>


### PR DESCRIPTION
Frontend half of the ticket-subjects feature (discussion #89). Pairs with the Laravel backend in **escalated-laravel#122**.

A ticket can now reference host-app entities it's *about* (Project, Customer, asset, …). The backend serializes them on the ticket as `subjects[]` (`type, id, role, title, subtitle, url, color, icon`), built from the `TicketSubject` presentation contract. This PR renders them.

## What's included

- **`TicketSubjects.vue`** — a "Related" card listing each subject with a colored monogram (from `color`), title, subtitle, and optional role. Subjects with a `url` render as clickable rows (open in a new tab, `rel="noopener noreferrer"`); subjects without one are static. Dark-mode aware (matches the existing sidebar theming), and the card is hidden entirely when there are no subjects.
- Wired into **`TicketSidebar.vue`** right under the Details card, so it shows on both the admin and agent ticket detail pages.
- **Storybook story** (`Single`, `Multiple`, `Empty`).

## Notes

- Reads `ticket.subjects` defensively (`|| []`), so it's a no-op against backends that don't yet expose the field — safe to merge ahead of the backend rollout.
- Matches the existing `TicketSidebar` convention (plain strings + `esc-dark` theming) rather than introducing `$t()` that the surrounding file doesn't use; broader sidebar localization is a separate concern.

## Tests

`eslint --max-warnings 0` + `prettier --check` clean; full frontend suite green (532 tests).
