### PR TITLE
test(reply-thread): regression for the 'Unknown' author bug

### DIFF
--- a/tests/components/ReplyThread.test.js
+++ b/tests/components/ReplyThread.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import ReplyThread from '../../src/components/ReplyThread.vue';
+
+// Regression for the "Unknown author on a just-posted reply" bug: ReplyThread
+// must render the author's name whenever the reply has an `author`, and fall
+// back to "Unknown" only when the reply genuinely has none. (The backend fix
+// ensures the author is present in the payload — escalated-laravel.)
+
+vi.mock('@inertiajs/vue3', () => ({ router: { post: vi.fn() } }));
+vi.mock('../../src/composables/useI18n', () => ({
+    useI18n: () => ({ t: (key) => key }),
+}));
+
+function mountThread(replies) {
+    return mount(ReplyThread, {
+        props: { replies, ticketReference: 'ESC-1', routePrefix: 'escalated.agent' },
+        global: { stubs: { AttachmentList: true, TicketSplitDialog: true } },
+    });
+}
+
+describe('ReplyThread author rendering', () => {
+    it('renders the author name when the reply has an author', () => {
+        const wrapper = mountThread([
+            { id: 1, body: 'On it!', author: { id: 7, name: 'Dana Agent' }, created_at: '2026-01-01T00:00:00Z' },
+        ]);
+
+        expect(wrapper.text()).toContain('Dana Agent');
+        expect(wrapper.text()).not.toContain('ticket.unknown');
+    });
+
+    it('falls back to "Unknown" only when the reply genuinely has no author', () => {
+        const wrapper = mountThread([
+            { id: 2, body: 'Automated message', author: null, created_at: '2026-01-01T00:00:00Z' },
+        ]);
+
+        expect(wrapper.text()).toContain('ticket.unknown');
+    });
+});


### PR DESCRIPTION
Frontend regression test for the newly-posted-reply 'Unknown author' bug (escalated-dev/escalated-laravel#123).

Adds `tests/components/ReplyThread.test.js` asserting `ReplyThread` renders the reply author's name when the reply has an `author`, and falls back to `ticket.unknown` only when it genuinely has none.

The root-cause fix is backend (the `ReplyCreated` broadcast payload shipped a null author) in escalated-laravel#124; this guards the shared component so the regression can't silently return. Vitest green (2/2); eslint/prettier clean.