### PR TITLE
fix(tickets): guard Assign-to-me crash + re-sync FollowButton on prop change

### DIFF
--- a/src/components/FollowButton.vue
+++ b/src/components/FollowButton.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, inject } from 'vue';
+import { ref, computed, inject, watch } from 'vue';
 import { router } from '@inertiajs/vue3';
 
 const props = defineProps({
@@ -15,6 +15,25 @@ const escDark = inject(
 const following = ref(props.isFollowing);
 const count = ref(props.followersCount);
 const processing = ref(false);
+
+// Re-sync local state when the props change. Inertia reuses this component
+// instance when navigating between tickets (Vue does not re-run setup), so the
+// refs above are only seeded from the FIRST ticket's props. Without these
+// watchers the button shows a stale follow state — e.g. an already-followed
+// ticket renders as "Follow" — and the optimistic toggle below would also
+// drift from the server's authoritative value after a reload.
+watch(
+    () => props.isFollowing,
+    (value) => {
+        following.value = value;
+    },
+);
+watch(
+    () => props.followersCount,
+    (value) => {
+        count.value = value;
+    },
+);
 
 function toggle() {
     if (processing.value) return;

--- a/src/pages/Admin/Tickets/Show.vue
+++ b/src/pages/Admin/Tickets/Show.vue
@@ -52,7 +52,12 @@ function changePriority(priority) {
 }
 
 function assignToMe() {
-    assignForm.agent_id = page.props.auth.user.id;
+    // auth.user may be absent if the host app hasn't shared it (other call
+    // sites in this page already guard with auth?.user?.id). Bail rather than
+    // crash on the click.
+    const userId = page.props.auth?.user?.id;
+    if (userId == null) return;
+    assignForm.agent_id = userId;
     assignForm.post(route('escalated.admin.tickets.assign', props.ticket.reference), { preserveScroll: true });
 }
 

--- a/src/pages/Agent/TicketShow.vue
+++ b/src/pages/Agent/TicketShow.vue
@@ -66,7 +66,12 @@ function changePriority(priority) {
 }
 
 function assignToMe() {
-    assignForm.agent_id = page.props.auth.user.id;
+    // auth.user may be absent if the host app hasn't shared it (other call
+    // sites in this page already guard with auth?.user?.id). Bail rather than
+    // crash on the click.
+    const userId = page.props.auth?.user?.id;
+    if (userId == null) return;
+    assignForm.agent_id = userId;
     assignForm.post(route('escalated.agent.tickets.assign', props.ticket.reference), { preserveScroll: true });
 }
 

--- a/tests/components/FollowButton.test.js
+++ b/tests/components/FollowButton.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { computed } from 'vue';
+import FollowButton from '../../src/components/FollowButton.vue';
+
+// Stub Inertia
+vi.mock('@inertiajs/vue3', () => ({
+    router: { post: vi.fn() },
+}));
+
+function mountButton(props = {}, dark = false) {
+    return mount(FollowButton, {
+        props: { action: '/follow', ...props },
+        global: {
+            provide: {
+                'esc-dark': computed(() => dark),
+            },
+        },
+    });
+}
+
+describe('FollowButton', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the seeded follow state', () => {
+        expect(mountButton({ isFollowing: false }).text()).toContain('Follow');
+        expect(mountButton({ isFollowing: true }).text()).toContain('Following');
+    });
+
+    // Regression: Inertia reuses this component instance when navigating between
+    // tickets, so setup() does not re-run. The button must re-sync to the new
+    // prop value — otherwise an already-followed ticket renders as "Follow".
+    it('updates the label when the isFollowing prop changes (no remount)', async () => {
+        const wrapper = mountButton({ isFollowing: false });
+        expect(wrapper.text()).toContain('Follow');
+        expect(wrapper.text()).not.toContain('Following');
+
+        await wrapper.setProps({ isFollowing: true });
+
+        expect(wrapper.text()).toContain('Following');
+        expect(wrapper.attributes('aria-pressed')).toBe('true');
+    });
+
+    it('updates the follower count when the prop changes', async () => {
+        const wrapper = mountButton({ isFollowing: true, followersCount: 2 });
+        expect(wrapper.text()).toContain('2');
+
+        await wrapper.setProps({ followersCount: 5 });
+
+        expect(wrapper.text()).toContain('5');
+    });
+
+    it('optimistically toggles on click via router.post onSuccess', async () => {
+        const { router } = await import('@inertiajs/vue3');
+        router.post.mockImplementation((url, data, opts) => opts.onSuccess?.());
+
+        const wrapper = mountButton({ isFollowing: false });
+        await wrapper.find('button').trigger('click');
+
+        expect(router.post).toHaveBeenCalledTimes(1);
+        expect(wrapper.text()).toContain('Following');
+    });
+});


### PR DESCRIPTION
Fixes #93.

Two production bugs on the agent/admin ticket view, both rooted in this shared frontend (so the fix reaches **all** backend hosts on the next `@escalated-dev/escalated` bump — no per-backend change needed).

## 1. "Assign to me" crash

`assignToMe()` read `page.props.auth.user.id` unguarded → `TypeError: Cannot read properties of undefined (reading 'user')` when the host hasn't shared `auth`. The same files already use the safe `auth?.user?.id` elsewhere. Now resolves the id defensively and bails instead of throwing.

- `src/pages/Admin/Tickets/Show.vue`
- `src/pages/Agent/TicketShow.vue`

## 2. FollowButton stale state

`src/components/FollowButton.vue` seeded `following` / `count` from props **once** at `setup()`. Inertia reuses the component instance across ticket navigation, so the refs never re-synced — an already-followed ticket rendered as "Follow". Added `watch`ers on `isFollowing` / `followersCount` so the button tracks the server's authoritative props. The optimistic on-click toggle is preserved for instant feedback.

## Tests

`tests/components/FollowButton.test.js` — seeded state, **prop re-sync without remount** (the regression), follower-count re-sync, and optimistic toggle. `vitest run` → 4/4. ESLint + Prettier clean (lint-staged ran on commit).

## Backend note

Laravel reference follow logic (`Ticket::follow` / `isFollowedBy`, the `following=true` index filter) was reviewed and is correct — no backend change required.
