### PR TITLE
fix(tickets): re-init TicketShow + PresenceIndicator on ticket navigation (stale-state audit)

### DIFF
--- a/src/components/PresenceIndicator.vue
+++ b/src/components/PresenceIndicator.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, inject, onMounted, onUnmounted } from 'vue';
+import { ref, computed, inject, onUnmounted, watch } from 'vue';
 
 const props = defineProps({
     ticketReference: { type: String, required: true },
@@ -20,6 +20,9 @@ const viewers = ref([]);
 const hovering = ref(false);
 let intervalId = null;
 let presenceChannel = null;
+// Track the exact channel name we joined so we leave the RIGHT channel when the
+// ticket changes — props.ticketId would already hold the new id by then.
+let joinedChannelName = null;
 
 async function fetchPresence() {
     try {
@@ -49,7 +52,8 @@ function initPresenceChannel() {
     if (!echoAvailable || !props.ticketId) return false;
 
     try {
-        presenceChannel = window.Echo.join(`escalated.tickets.${props.ticketId}`);
+        joinedChannelName = `escalated.tickets.${props.ticketId}`;
+        presenceChannel = window.Echo.join(joinedChannelName);
 
         presenceChannel
             .here((users) => {
@@ -99,29 +103,40 @@ function getColor(index) {
     return colors[index % colors.length];
 }
 
-onMounted(() => {
+function teardown() {
+    if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+    }
+    if (presenceChannel) {
+        try {
+            window.Echo.leave(joinedChannelName);
+        } catch {
+            // ignore
+        }
+        presenceChannel = null;
+        joinedChannelName = null;
+    }
+}
+
+function start() {
+    // Tear down any subscription for the previously viewed ticket first. Inertia
+    // reuses this component across ticket navigation, so without re-initialising
+    // we would keep showing the old ticket's viewers and leak its channel.
+    teardown();
+    viewers.value = [];
     // Prefer presence channels via Echo; fall back to polling
     const usingEcho = initPresenceChannel();
     if (!usingEcho) {
         fetchPresence();
         intervalId = setInterval(fetchPresence, effectiveInterval.value);
     }
-});
+}
 
-onUnmounted(() => {
-    if (intervalId) {
-        clearInterval(intervalId);
-        intervalId = null;
-    }
-    if (presenceChannel && props.ticketId) {
-        try {
-            window.Echo.leave(`escalated.tickets.${props.ticketId}`);
-        } catch {
-            // ignore
-        }
-        presenceChannel = null;
-    }
-});
+// (Re)initialise whenever the ticket identity changes; `immediate` covers mount.
+watch(() => [props.ticketId, props.ticketReference], start, { immediate: true });
+
+onUnmounted(teardown);
 </script>
 
 <template>

--- a/src/pages/Agent/TicketShow.vue
+++ b/src/pages/Agent/TicketShow.vue
@@ -24,7 +24,7 @@ import { usePluginExtensions } from '../../composables/usePluginExtensions';
 import { useRealtime } from '../../composables/useRealtime';
 import { useChat } from '../../composables/useChat';
 import { router, useForm, usePage } from '@inertiajs/vue3';
-import { ref, computed, inject, onMounted } from 'vue';
+import { ref, computed, inject, onUnmounted, watch } from 'vue';
 
 const props = defineProps({
     ticket: Object,
@@ -94,10 +94,29 @@ const chatTypingUser = ref(null);
 // serves Escalated under (config on NestJS, default /support elsewhere).
 const { subscribeToChat } = useChat({ widgetPath: widgetPath.value });
 let chatTypingTimer = null;
+let chatUnsubscribe = null;
 
-onMounted(() => {
+// Re-seed the chat thread whenever we navigate to a different ticket. Inertia
+// reuses this page component across ticket navigation (setup() does not re-run),
+// so without this the previous ticket's chat would persist.
+watch(
+    () => props.ticket.id,
+    () => {
+        chatMessages.value = props.ticket.chat_messages || [];
+    },
+);
+
+// (Re)subscribe to the chat channel whenever the live chat session changes —
+// including navigating from a non-chat ticket to a chat ticket. The old
+// subscription is torn down first so we never leak a channel or receive
+// messages for the ticket we just left.
+function setupChatSubscription() {
+    if (chatUnsubscribe) {
+        chatUnsubscribe();
+        chatUnsubscribe = null;
+    }
     if (!isChatMode.value || !props.ticket.chat_session_id) return;
-    subscribeToChat(props.ticket.chat_session_id, {
+    chatUnsubscribe = subscribeToChat(props.ticket.chat_session_id, {
         onMessage(data) {
             chatMessages.value.push(data.message);
         },
@@ -115,6 +134,15 @@ onMounted(() => {
             router.reload({ preserveScroll: true });
         },
     });
+}
+
+watch(() => [props.ticket.chat_session_id, isChatMode.value], setupChatSubscription, {
+    immediate: true,
+});
+
+onUnmounted(() => {
+    if (chatUnsubscribe) chatUnsubscribe();
+    clearTimeout(chatTypingTimer);
 });
 
 function onChatSend(payload) {
@@ -160,11 +188,21 @@ useKeyboardShortcuts({
 
 // Real-time updates via WebSocket (gracefully degrades to no-op when Echo is absent)
 const { echoAvailable, subscribeToTicket } = useRealtime();
+let ticketUnsubscribe = null;
 
-onMounted(() => {
+// (Re)subscribe whenever the ticket id changes. Because Inertia reuses this
+// page across ticket navigation, an onMounted-only subscription would stay
+// bound to the first ticket — realtime updates for the ticket you navigated to
+// would never arrive, and the previous ticket's events would keep triggering
+// reloads. Tear down the old subscription before binding the new one.
+function setupTicketSubscription() {
+    if (ticketUnsubscribe) {
+        ticketUnsubscribe();
+        ticketUnsubscribe = null;
+    }
     if (!echoAvailable.value || !props.ticket?.id) return;
 
-    subscribeToTicket(props.ticket.id, {
+    ticketUnsubscribe = subscribeToTicket(props.ticket.id, {
         onReplyCreated() {
             router.reload({ only: ['ticket'], preserveScroll: true });
         },
@@ -181,6 +219,12 @@ onMounted(() => {
             router.reload({ only: ['ticket'], preserveScroll: true });
         },
     });
+}
+
+watch(() => props.ticket?.id, setupTicketSubscription, { immediate: true });
+
+onUnmounted(() => {
+    if (ticketUnsubscribe) ticketUnsubscribe();
 });
 </script>
 


### PR DESCRIPTION
Follow-up to the FollowButton fix (#94). After that, I ran a **full audit** for the same two bug classes across `src`.

## Audit result

- **Class A — unguarded Inertia shared-prop access** (`page.props.auth.user.id` style): ✅ clean. The only instances were the `assignToMe` ones fixed in #94; every `auth.user` access is now `?.`-guarded.
- **Class C — template / computed null-derefs** on optional relations: ✅ clean. Consistently guarded (`v-if="ticket.department"`, `message.author?.id`, `props.department` checks, etc.).
- **Class B — local state seeded from props once, never re-synced**: ❌ found a real cluster. Root cause is the same thing that made the follow bug real — this app doesn't `key` Inertia page components, so navigating record→record reuses the instance and `setup()` / `onMounted` never re-run.

## Fixes in this PR (the High/Med findings)

All on the agent ticket view, fixed defensively (re-init on record change → correct whether or not the host keys pages):

1. **`Agent/TicketShow.vue` — chat messages.** `chatMessages` was seeded from `props.ticket` once → navigating between chat tickets showed the **previous** ticket's messages. Now `watch`es `props.ticket.id` and re-seeds.
2. **`Agent/TicketShow.vue` — chat WS subscription.** Bound once in `onMounted` → stayed on the old `chat_session_id`, and never subscribed if you arrived from a non-chat ticket. Now (re)subscribes via a `watch` on the session id, tearing down the previous subscription first.
3. **`Agent/TicketShow.vue` — ticket realtime subscription.** Bound once → after navigating, realtime updates for the opened ticket never arrived and the **old** ticket's events kept triggering reloads. Now (re)subscribes on `props.ticket.id`. (`useRealtime` / `useChat` already return unsubscribe fns; `onUnmounted` cleans up.)
4. **`PresenceIndicator.vue`** (used on both show pages). Joined the Echo presence channel / started polling once → viewer avatars stayed bound to the previously viewed ticket and leaked its channel. Re-initialises on `ticketId` / `ticketReference` change and leaves the exact channel it joined.

## Deferred (Low — not fixed here)

Index filter inputs (`ref(props.filters?.search)`), report `periodDays`, and `ActiveChatsPanel.currentStatus` are seeded-once but user-driven / one-way; only stale on a back-button and arguably intentional. Happy to add `watch`es to those too if you want strict prop-tracking.

## Verification

`vitest run` → **538/538**. ESLint + Prettier clean (lint-staged ran on commit). No build step (consumed as source).

> Note: like #94, these land in the shared frontend, so methodclass and the other hosts only pick them up after a `@escalated-dev/escalated` release + dependency bump.
