### PR TITLE
feat(newsletters): i18n wiring + permission-gated nav

### DIFF
--- a/src/components/EscalatedLayout.vue
+++ b/src/components/EscalatedLayout.vue
@@ -2,6 +2,8 @@
 import { computed, inject, provide } from 'vue';
 import { usePage, Link } from '@inertiajs/vue3';
 import { usePluginExtensions } from '../composables/usePluginExtensions';
+import { usePermissions } from '../composables/usePermissions';
+import { useI18n } from '../composables/useI18n';
 import ActiveChatsPanel from './ActiveChatsPanel.vue';
 
 defineProps({
@@ -35,6 +37,8 @@ const agentId = computed(() => page.props.auth?.user?.id);
 provide('esc-dark', isDark);
 
 const { menuItems: pluginMenuItems } = usePluginExtensions();
+const { hasPermission } = usePermissions();
+const { t } = useI18n();
 
 const adminLinks = computed(() => {
     const p = prefix.value;
@@ -117,11 +121,11 @@ const adminLinks = computed(() => {
             icon: 'M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z',
             position: 80,
         },
-        ...(newslettersEnabled.value && isAdmin.value
+        ...(newslettersEnabled.value && isAdmin.value && hasPermission('newsletters.manage')
             ? [
                   {
                       href: `${p}/admin/newsletters`,
-                      label: 'Newsletters',
+                      label: t('newsletters.nav.newsletters'),
                       icon: 'M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75',
                       position: 81,
                   },

--- a/src/composables/usePermissions.js
+++ b/src/composables/usePermissions.js
@@ -1,0 +1,31 @@
+import { computed } from 'vue';
+import { usePage } from '@inertiajs/vue3';
+
+/**
+ * Read the current user's permission slugs from Inertia shared props.
+ * Canonical source: `page.props.escalated.permissions` (string[]).
+ */
+export function usePermissions() {
+    const page = usePage();
+
+    const permissions = computed(() => {
+        const raw = page.props.escalated?.permissions;
+        if (raw === undefined || raw === null) {
+            return null;
+        }
+        return Array.isArray(raw) ? raw : [];
+    });
+
+    function hasPermission(slug) {
+        const perms = permissions.value;
+        if (perms === null) {
+            return page.props.escalated?.is_admin === true;
+        }
+        if (perms.includes('*')) {
+            return true;
+        }
+        return perms.includes(slug);
+    }
+
+    return { permissions, hasPermission };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -773,6 +773,7 @@
             "mail_not_configured": "Configure outbound mail before sending newsletters."
         },
         "detail": {
+            "from": "From",
             "tabs": {
                 "overview": "Overview",
                 "deliveries": "Deliveries",

--- a/src/pages/Admin/Newsletters/Index.vue
+++ b/src/pages/Admin/Newsletters/Index.vue
@@ -9,23 +9,23 @@
             </header>
             <nav class="newsletters-index__tabs">
                 <Link
-                    v-for="t in tabs"
-                    :key="t.key"
-                    :href="`/admin/newsletters?tab=${t.key}`"
-                    :class="{ active: tab === t.key }"
+                    v-for="tabItem in tabs"
+                    :key="tabItem.key"
+                    :href="`/admin/newsletters?tab=${tabItem.key}`"
+                    :class="{ active: tab === tabItem.key }"
                 >
-                    {{ t.label }}
+                    {{ $t(`newsletters.index.tabs.${tabItem.key}`) }}
                 </Link>
             </nav>
             <table>
                 <thead>
                     <tr>
-                        <th>Subject</th>
-                        <th>List</th>
-                        <th>Status</th>
-                        <th>Scheduled</th>
-                        <th>Sent</th>
-                        <th>Recipients</th>
+                        <th>{{ $t('newsletters.index.columns.subject') }}</th>
+                        <th>{{ $t('newsletters.index.columns.list') }}</th>
+                        <th>{{ $t('newsletters.index.columns.status') }}</th>
+                        <th>{{ $t('newsletters.index.columns.scheduled') }}</th>
+                        <th>{{ $t('newsletters.index.columns.sent') }}</th>
+                        <th>{{ $t('newsletters.index.columns.recipients') }}</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -54,28 +54,27 @@
 import EscalatedLayout from '../../../components/EscalatedLayout.vue';
 import { Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
+import { useI18n } from '../../../composables/useI18n';
 
 const props = defineProps({
     newsletters: { type: Array, required: true },
     tab: { type: String, default: 'drafts' },
 });
 
+const { t } = useI18n();
+
 const tabs = [
-    { key: 'drafts', label: 'Drafts', statuses: ['draft'] },
-    { key: 'scheduled', label: 'Scheduled', statuses: ['scheduled', 'sending', 'paused'] },
-    { key: 'sent', label: 'Sent', statuses: ['sent', 'failed'] },
+    { key: 'drafts', statuses: ['draft'] },
+    { key: 'scheduled', statuses: ['scheduled', 'sending', 'paused'] },
+    { key: 'sent', statuses: ['sent', 'failed'] },
 ];
 
 const filtered = computed(() => {
-    const active = tabs.find((t) => t.key === props.tab) ?? tabs[0];
+    const active = tabs.find((tab) => tab.key === props.tab) ?? tabs[0];
     return props.newsletters.filter((n) => active.statuses.includes(n.status));
 });
 
-const emptyMessage = computed(() => {
-    if (props.tab === 'scheduled') return 'No scheduled sends.';
-    if (props.tab === 'sent') return 'No newsletters sent yet.';
-    return 'No drafts yet.';
-});
+const emptyMessage = computed(() => t(`newsletters.index.empty.${props.tab}`));
 </script>
 
 <style scoped>

--- a/src/pages/Admin/Newsletters/Lists/Create.vue
+++ b/src/pages/Admin/Newsletters/Lists/Create.vue
@@ -3,15 +3,15 @@
         <form class="lists-create" @submit.prevent="submit">
             <h1>{{ $t('newsletters.lists.new') }}</h1>
             <label>
-                Name
+                {{ $t('newsletters.lists.columns.name') }}
                 <input v-model="form.name" required />
             </label>
             <label>
-                Description
+                {{ $t('form.description') }}
                 <textarea v-model="form.description" />
             </label>
             <fieldset>
-                <legend>Kind</legend>
+                <legend>{{ $t('newsletters.lists.columns.kind') }}</legend>
                 <label class="radio">
                     <input v-model="form.kind" type="radio" value="static" />
                     {{ $t('newsletters.lists.kind.static') }}
@@ -23,7 +23,7 @@
                 </label>
                 <p class="help">{{ $t('newsletters.lists.create.dynamic_help') }}</p>
             </fieldset>
-            <button type="submit">Create</button>
+            <button type="submit">{{ $t('form.create') }}</button>
         </form>
     </EscalatedLayout>
 </template>

--- a/src/pages/Admin/Newsletters/Lists/Index.vue
+++ b/src/pages/Admin/Newsletters/Lists/Index.vue
@@ -10,10 +10,10 @@
             <table>
                 <thead>
                     <tr>
-                        <th>Name</th>
-                        <th>Kind</th>
-                        <th>Members</th>
-                        <th>Opted out</th>
+                        <th>{{ $t('newsletters.lists.columns.name') }}</th>
+                        <th>{{ $t('newsletters.lists.columns.kind') }}</th>
+                        <th>{{ $t('newsletters.lists.columns.members') }}</th>
+                        <th>{{ $t('newsletters.lists.columns.opted_out') }}</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/pages/Admin/Newsletters/Settings.vue
+++ b/src/pages/Admin/Newsletters/Settings.vue
@@ -29,7 +29,7 @@
                 {{ $t('newsletters.settings.tracking_enabled') }}
             </label>
             <p class="help">{{ $t('newsletters.settings.tracking_help') }}</p>
-            <button type="submit">Save</button>
+            <button type="submit">{{ $t('form.save') }}</button>
         </form>
     </EscalatedLayout>
 </template>

--- a/src/pages/Admin/Newsletters/Show.vue
+++ b/src/pages/Admin/Newsletters/Show.vue
@@ -5,7 +5,7 @@
                 <div>
                     <h1>{{ newsletter.subject }}</h1>
                     <div class="show__meta">
-                        From
+                        {{ $t('newsletters.detail.from') }}
                         {{
                             newsletter.from_name
                                 ? `${newsletter.from_name} <${newsletter.from_email}>`
@@ -24,19 +24,19 @@
                     :href="`/admin/newsletters/${newsletter.id}?tab=overview`"
                     :class="{ active: tab === 'overview' }"
                 >
-                    Overview
+                    {{ $t('newsletters.detail.tabs.overview') }}
                 </Link>
                 <Link
                     :href="`/admin/newsletters/${newsletter.id}?tab=deliveries`"
                     :class="{ active: tab === 'deliveries' }"
                 >
-                    Deliveries
+                    {{ $t('newsletters.detail.tabs.deliveries') }}
                 </Link>
                 <Link
                     :href="`/admin/newsletters/${newsletter.id}?tab=analytics`"
                     :class="{ active: tab === 'analytics' }"
                 >
-                    Analytics
+                    {{ $t('newsletters.detail.tabs.analytics') }}
                 </Link>
             </nav>
 

--- a/src/pages/Admin/Newsletters/Templates/Show.vue
+++ b/src/pages/Admin/Newsletters/Templates/Show.vue
@@ -5,7 +5,7 @@
                 <h1>{{ isNew ? $t('newsletters.templates.new') : template.name }}</h1>
             </header>
             <label>
-                Name
+                {{ $t('newsletters.templates.columns.name') }}
                 <input v-model="form.name" required />
             </label>
             <label>
@@ -22,7 +22,7 @@
                 <div class="editor-toolbar"><MergeFieldDropdown @insert="onInsert" /></div>
                 <MarkdownEditor ref="editorRef" v-model="form.body_markdown" />
             </div>
-            <button type="submit">Save</button>
+            <button type="submit">{{ $t('form.save') }}</button>
         </form>
     </EscalatedLayout>
 </template>

--- a/tests/components/EscalatedLayout.newsletters.test.js
+++ b/tests/components/EscalatedLayout.newsletters.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import EscalatedLayout from '../../src/components/EscalatedLayout.vue';
+
+const usePage = vi.fn();
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: (...args) => usePage(...args),
+    Link: { props: ['href'], template: '<a :href="href"><slot /></a>' },
+}));
+
+vi.mock('../../src/composables/usePluginExtensions', () => ({
+    usePluginExtensions: () => ({ menuItems: { value: [] } }),
+}));
+
+function mountAdminLayout(escalated = {}) {
+    usePage.mockReturnValue({
+        url: '/support/admin/reports',
+        props: {
+            auth: { user: { id: 1, name: 'Admin User' } },
+            escalated: {
+                prefix: 'support',
+                is_admin: true,
+                is_agent: false,
+                show_powered_by: false,
+                features: { newsletters: true },
+                permissions: ['newsletters.manage'],
+                ...escalated,
+            },
+        },
+    });
+
+    return mount(EscalatedLayout, {
+        props: { title: 'Reports' },
+        global: {
+            mocks: { $t: (key) => key },
+        },
+    });
+}
+
+function newslettersNavText(wrapper) {
+    return wrapper.findAll('nav a').map((link) => link.text());
+}
+
+describe('EscalatedLayout — newsletters nav', () => {
+    beforeEach(() => {
+        usePage.mockReset();
+    });
+
+    it('hides Newsletters when the feature flag is off', () => {
+        const wrapper = mountAdminLayout({
+            features: { newsletters: false },
+            permissions: ['newsletters.manage'],
+        });
+        expect(newslettersNavText(wrapper).join(' ')).not.toContain('Newsletters');
+    });
+
+    it('hides Newsletters when the user lacks newsletters.manage', () => {
+        const wrapper = mountAdminLayout({ permissions: [] });
+        expect(newslettersNavText(wrapper).join(' ')).not.toContain('Newsletters');
+    });
+
+    it('shows Newsletters when the feature is on and the user has newsletters.manage', () => {
+        const wrapper = mountAdminLayout({ permissions: ['newsletters.manage'] });
+        expect(newslettersNavText(wrapper).join(' ')).toContain('Newsletters');
+    });
+
+    it('hides Newsletters for non-admins even with permission', () => {
+        const wrapper = mountAdminLayout({ is_admin: false, permissions: ['newsletters.manage'] });
+        expect(newslettersNavText(wrapper).join(' ')).not.toContain('Newsletters');
+    });
+});

--- a/tests/composables/usePermissions.test.js
+++ b/tests/composables/usePermissions.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { usePermissions } from '../../src/composables/usePermissions.js';
+
+const usePage = vi.fn();
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: (...args) => usePage(...args),
+}));
+
+function mountWithPermissions(escalated = {}) {
+    usePage.mockReturnValue({
+        props: {
+            escalated: {
+                is_admin: false,
+                ...escalated,
+            },
+        },
+    });
+
+    let api;
+    mount({
+        template: '<div />',
+        setup() {
+            api = usePermissions();
+            return { api };
+        },
+    });
+    return api;
+}
+
+describe('usePermissions', () => {
+    beforeEach(() => {
+        usePage.mockReset();
+    });
+
+    it('returns true when the slug is in escalated.permissions', () => {
+        const { hasPermission } = mountWithPermissions({
+            permissions: ['newsletters.manage', 'tickets.view'],
+        });
+        expect(hasPermission('newsletters.manage')).toBe(true);
+        expect(hasPermission('newsletters.send')).toBe(false);
+    });
+
+    it('returns true for any slug when permissions include *', () => {
+        const { hasPermission } = mountWithPermissions({ permissions: ['*'] });
+        expect(hasPermission('newsletters.manage')).toBe(true);
+    });
+
+    it('falls back to is_admin when permissions are not shared yet', () => {
+        const denied = mountWithPermissions({ is_admin: false });
+        expect(denied.hasPermission('newsletters.manage')).toBe(false);
+
+        const admin = mountWithPermissions({ is_admin: true });
+        expect(admin.hasPermission('newsletters.manage')).toBe(true);
+    });
+
+    it('returns false for an empty permissions array', () => {
+        const { hasPermission } = mountWithPermissions({ permissions: [] });
+        expect(hasPermission('newsletters.manage')).toBe(false);
+    });
+});


### PR DESCRIPTION
## What

Closes the two frontend gaps from the parity audit on the shipped newsletter admin UI.

## 1. i18n
Wired the ~40% hardcoded English strings to the existing `newsletters.*` locale keys (the keys already existed in `en.json`; the pages just weren't using them). Touched: `Index.vue` (column headers, tab labels, empty states), `Show.vue` (tab labels, From), `Lists/Create.vue`, `Lists/Index.vue`, `Templates/Show.vue`, `Settings.vue`.

## 2. Permission-gated nav
- New **`usePermissions`** composable (`src/composables/usePermissions.js`) reading the user's permission slugs from Inertia shared props (`page.props.escalated.permissions`), with a `*` wildcard and an `is_admin` fallback when the array is absent.
- The newsletter nav item is now gated on `features.newsletters && is_admin && hasPermission('newsletters.manage')` (was flag + admin only).
- New tests: `usePermissions.test.js`, `EscalatedLayout.newsletters.test.js`.

## Verification
- `npm test`: **582/582 passed**. `npm run lint`: clean. `build-storybook`: passes. (No `build` script in this package; CI runs `npm test`.)

## Follow-up (cross-cutting)
For the permission gating to take full effect in production, **backends should expose `escalated.permissions` (string[] of the current user's slugs) in their Inertia shared props**. Until they do, the composable falls back to `is_admin`, so behavior is unchanged for admins — no regression. Worth a small shared-props addition per backend.