### PR TITLE
feat(plugins): make ZIP upload optional on admin Plugins page

### DIFF
--- a/src/pages/Admin/Plugins/Index.vue
+++ b/src/pages/Admin/Plugins/Index.vue
@@ -5,6 +5,10 @@ import { ref, computed } from 'vue';
 
 const props = defineProps({
     plugins: { type: Array, default: () => [] },
+    // Backends that load plugins from uploaded ZIPs (e.g. Laravel) support the
+    // upload flow; backends where plugins are compiled host modules registered
+    // in config (e.g. Phoenix) pass can_upload: false to hide it.
+    can_upload: { type: Boolean, default: true },
 });
 
 const confirmingDelete = ref(null);
@@ -93,7 +97,7 @@ function statusLabel(plugin) {
                     {{ activePlugins.length }} active, {{ inactivePlugins.length }} inactive
                 </p>
             </div>
-            <div>
+            <div v-if="can_upload">
                 <input ref="fileInput" type="file" accept=".zip" class="hidden" @change="handleUpload" />
                 <button
                     :disabled="uploading"
@@ -144,8 +148,11 @@ function statusLabel(plugin) {
                 />
             </svg>
             <h3 class="text-sm font-medium text-[var(--esc-panel-text-secondary)]">No plugins installed</h3>
-            <p class="mt-1 text-xs text-[var(--esc-panel-text-muted)]">
+            <p v-if="can_upload" class="mt-1 text-xs text-[var(--esc-panel-text-muted)]">
                 Upload a plugin ZIP to extend Escalated with custom functionality.
+            </p>
+            <p v-else class="mt-1 text-xs text-[var(--esc-panel-text-muted)]">
+                Register a plugin in the host application to extend Escalated with custom functionality.
             </p>
         </div>
 
@@ -234,6 +241,7 @@ function statusLabel(plugin) {
                                 </svg>
                                 Installed {{ plugin.installed_at }}
                             </span>
+                            <span v-if="plugin.module" class="font-mono">{{ plugin.module }}</span>
                         </div>
 
                         <!-- Provided extensions summary -->


### PR DESCRIPTION
The admin **Plugins** page (`Admin/Plugins/Index.vue`) was built for the Laravel plugin model, which loads plugins from uploaded ZIPs. Backends where plugins are **compiled host modules registered in config** (Phoenix, and any future module-based backend) have no upload endpoint — but the page always rendered an Upload button that called `route('escalated.admin.plugins.upload')`, an undefined route on those backends.

## Change

- Add a `can_upload` prop (**default `true`**, so Laravel is completely unchanged). When `false`, the Upload button is hidden and the empty-state copy switches from "Upload a plugin ZIP…" to "Register a plugin in the host application…".
- Surface `plugin.module` (sent by module-based backends) as a small monospace detail in the plugin card meta row.

All other Laravel-only fields (`author`, `homepage`, `installed_at`, `provides`, `source`) already degrade via `v-if`, so a leaner backend prop set renders cleanly. `can_upload` follows the existing snake_case top-level prop convention (cf. `api_enabled` in `ApiTokens/Index.vue`).

Backends opt out by passing `can_upload: false`; a matching change lands in escalated-phoenix's `PluginController`.

## Verification

- `prettier --check` — clean
- `eslint --max-warnings 0` — clean
- `vitest run` — **582 tests passing**